### PR TITLE
Add support for docker-compose deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update -y && \
-    apt-get install -y python3-pip python3-dev && \
+    apt-get install -y python3-pip && \
     apt-get install -y sqlite3 && \
     apt-get install -y libffi-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Copyright 2020 The SODA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:16.04
+
+RUN apt-get update -y && \
+    apt-get install -y python3-pip python3-dev && \
+    apt-get install -y sqlite3 && \
+    apt-get install -y libffi-dev
+
+ADD . /SIM
+WORKDIR /SIM
+
+RUN mkdir -p /var/log/SIM
+RUN mkdir -p /var/lib/dolphin/
+
+RUN pip3 install --upgrade pip
+RUN pip3 install -r requirements.txt
+
+COPY etc/dolphin/api-paste.ini /etc/dolphin/api-paste.ini
+COPY etc/dolphin/dolphin.conf /etc/dolphin/dolphin.conf
+
+COPY script/start.sh start.sh
+
+CMD ./start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,17 +19,17 @@ RUN apt-get update -y && \
     apt-get install -y sqlite3 && \
     apt-get install -y libffi-dev
 
-ADD . /SIM
-WORKDIR /SIM
+ADD . /delfin
+WORKDIR /delfin
 
-RUN mkdir -p /var/log/SIM
-RUN mkdir -p /var/lib/dolphin/
+RUN mkdir -p /var/log/delfin
+RUN mkdir -p /var/lib/delfin/
 
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
 
-COPY etc/dolphin/api-paste.ini /etc/dolphin/api-paste.ini
-COPY etc/dolphin/dolphin.conf /etc/dolphin/dolphin.conf
+COPY etc/delfin/api-paste.ini /etc/delfin/api-paste.ini
+COPY etc/delfin/delfin.conf /etc/delfin/delfin.conf
 
 COPY script/start.sh start.sh
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+# Copyright 2020 The SODA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+version: '3'
+
+services:
+
+  redis:
+    image: redis
+    container_name: redis
+    command: redis-server
+    ports:
+      - "6379:6379"
+
+  rabbitmq:
+      image: rabbitmq:3-management
+      container_name: rabbitmq
+      volumes:
+          - ./.docker/rabbitmq/logs/:/var/log/rabbitmq/
+      environment:
+          RABBITMQ_DEFAULT_USER: "sim"
+          RABBITMQ_DEFAULT_PASS: "simpass"
+          RABBITMQ_DEFAULT_VHOST: "/"
+      ports:
+          - 5672:5672
+          - 15672:15672
+
+  soda-sim:
+    image: soda-sim
+    volumes:
+      - /var/log/dolphin:/var/log/dolphin
+    ports:
+      - 8190:8190
+    environment:
+      - OS_COORDINATION__BACKEND_SERVER=192.168.20.158:6379
+      - OS_DEFAULT__TRANSPORT_URL=rabbit://sim:simpass@192.168.20.158:5672//

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,19 +30,19 @@ services:
       volumes:
           - ./.docker/rabbitmq/logs/:/var/log/rabbitmq/
       environment:
-          RABBITMQ_DEFAULT_USER: ${SIM_RABBITMQ_USER}
-          RABBITMQ_DEFAULT_PASS: ${SIM_RABBITMQ_PASS}
+          RABBITMQ_DEFAULT_USER: ${DELFIN_RABBITMQ_USER}
+          RABBITMQ_DEFAULT_PASS: ${DELFIN_RABBITMQ_PASS}
           RABBITMQ_DEFAULT_VHOST: "/"
       ports:
           - 5672:5672
           - 15672:15672
 
-  soda-sim:
-    image: soda-sim
+  delfin:
+    image: sodafoundation/delfin
     volumes:
-      - /var/log/dolphin:/var/log/dolphin
+      - /var/log/delfin:/var/log/delfin
     ports:
       - 8190:8190
     environment:
-      - OS_COORDINATION__BACKEND_SERVER=${SIM_HOST_IP}:6379
-      - OS_DEFAULT__TRANSPORT_URL=rabbit://${SIM_RABBITMQ_USER}:${SIM_RABBITMQ_PASS}@${SIM_HOST_IP}:5672//
+      - OS_COORDINATION__BACKEND_SERVER=${DELFIN_HOST_IP}:6379
+      - OS_DEFAULT__TRANSPORT_URL=rabbit://${DELFIN_RABBITMQ_USER}:${DELFIN_RABBITMQ_PASS}@${DELFIN_HOST_IP}:5672//

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-version: '3'
+version: '2'
 
 services:
 
@@ -30,8 +30,8 @@ services:
       volumes:
           - ./.docker/rabbitmq/logs/:/var/log/rabbitmq/
       environment:
-          RABBITMQ_DEFAULT_USER: "sim"
-          RABBITMQ_DEFAULT_PASS: "simpass"
+          RABBITMQ_DEFAULT_USER: ${SIM_RABBITMQ_USER}
+          RABBITMQ_DEFAULT_PASS: ${SIM_RABBITMQ_PASS}
           RABBITMQ_DEFAULT_VHOST: "/"
       ports:
           - 5672:5672
@@ -44,5 +44,5 @@ services:
     ports:
       - 8190:8190
     environment:
-      - OS_COORDINATION__BACKEND_SERVER=192.168.20.158:6379
-      - OS_DEFAULT__TRANSPORT_URL=rabbit://sim:simpass@192.168.20.158:5672//
+      - OS_COORDINATION__BACKEND_SERVER=${SIM_HOST_IP}:6379
+      - OS_DEFAULT__TRANSPORT_URL=rabbit://${SIM_RABBITMQ_USER}:${SIM_RABBITMQ_PASS}@${SIM_HOST_IP}:5672//

--- a/script/create_db.py
+++ b/script/create_db.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+# Copyright 2020 The SODA Authors.
+# Copyright 2010 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""db create  script for dolphin """
+
+
+
+import sys
+
+from oslo_config import cfg
+
+from dolphin import  db
+from dolphin import version
+
+CONF = cfg.CONF
+
+
+def main():
+
+    CONF(sys.argv[1:], project='dolphin',
+         version=version.version_string())
+    db.register_db()
+
+
+if __name__ == '__main__':
+    main()

--- a/script/create_db.py
+++ b/script/create_db.py
@@ -17,7 +17,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-"""db create  script for dolphin """
+"""db create  script for delfin """
 
 
 
@@ -25,15 +25,15 @@ import sys
 
 from oslo_config import cfg
 
-from dolphin import  db
-from dolphin import version
+from delfin import  db
+from delfin import version
 
 CONF = cfg.CONF
 
 
 def main():
 
-    CONF(sys.argv[1:], project='dolphin',
+    CONF(sys.argv[1:], project='delfin',
          version=version.version_string())
     db.register_db()
 

--- a/script/start.sh
+++ b/script/start.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The SODA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+python3 setup.py install
+
+python3 script/create_db.py --config-file /etc/dolphin/dolphin.conf
+
+sleep 10
+
+python3 dolphin/cmd/api.py --config-file /etc/dolphin/dolphin.conf > /var/log/dolphin/api.log 2>&1 &
+
+python3 dolphin/cmd/task.py --config-file /etc/dolphin/dolphin.conf > /var/log/dolphin/task.log 2>&1 &
+
+python3 dolphin/cmd/alert.py --config-file /etc/dolphin/dolphin.conf > /var/log/dolphin/alert.log 2>&1

--- a/script/start.sh
+++ b/script/start.sh
@@ -16,12 +16,12 @@
 
 python3 setup.py install
 
-python3 script/create_db.py --config-file /etc/dolphin/dolphin.conf
+python3 script/create_db.py --config-file /etc/delfin/delfin.conf
 
 sleep 10
 
-python3 dolphin/cmd/api.py --config-file /etc/dolphin/dolphin.conf > /var/log/dolphin/api.log 2>&1 &
+python3 delfin/cmd/api.py --config-file /etc/delfin/delfin.conf > /var/log/delfin/api.log 2>&1 &
 
-python3 dolphin/cmd/task.py --config-file /etc/dolphin/dolphin.conf > /var/log/dolphin/task.log 2>&1 &
+python3 delfin/cmd/task.py --config-file /etc/delfin/delfin.conf > /var/log/delfin/task.log 2>&1 &
 
-python3 dolphin/cmd/alert.py --config-file /etc/dolphin/dolphin.conf > /var/log/dolphin/alert.log 2>&1
+python3 delfin/cmd/alert.py --config-file /etc/delfin/delfin.conf > /var/log/delfin/alert.log 2>&1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add support for docker-compose deployment.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

issue #221 

**Special notes for your reviewer**:
Installation Steps:
1. Create the 'sodafoundation/delfin' docker image with Dockerfile in delfin project using command below. (Note: In future we will upload this image to docker-hub and it can be downloaded with out this step)

**$ docker build -t sodafoundation/delfin .**

2. Export envirnment vars for IP addresses and rabbitmq credentials
**$ export DELFIN_RABBITMQ_USER=delfinuser
$ export DELFIN_RABBITMQ_PASS=delfinpass
$ export DELFIN_HOST_IP=192.168.0.2** 

3. Bring up delfin project using following command

**$ docker-compose up -d**

4. When finished using delfin project, bring down containers using following command

**$ docker-compose down**


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
