### PR TITLE
Check the update_at value before using

### DIFF
--- a/dolphin/api/v1/storages.py
+++ b/dolphin/api/v1/storages.py
@@ -193,8 +193,11 @@ def _set_synced_if_ok(context, storage_id, resource_count):
         raise exception.InvalidInput(message=msg)
     else:
         last_update = storage['updated_at']
-        current_time = datetime.now()
-        interval = (current_time - last_update).seconds
+        if last_update is None:
+            interval = 0
+        else:
+            current_time = datetime.now()
+            interval = (current_time - last_update).seconds
         # If last synchronization was within 30 minutes,
         # and the sync status is not SYNCED, it means some sync task
         # is still running, the new sync task should not launch

--- a/dolphin/api/v1/storages.py
+++ b/dolphin/api/v1/storages.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import copy
-from datetime import datetime
 
 from oslo_config import cfg
 from oslo_log import log
+from oslo_utils import timeutils
 
 from dolphin import coordination
 from dolphin import db
@@ -193,7 +193,7 @@ def _set_synced_if_ok(context, storage_id, resource_count):
         raise exception.InvalidInput(message=msg)
     else:
         last_update = storage['updated_at'] or storage['created_at']
-        current_time = datetime.now()
+        current_time = timeutils.utcnow()
         interval = (current_time - last_update).seconds
         # If last synchronization was within
         # CONF.sync_task_expiration(in seconds), and the sync status

--- a/dolphin/api/v1/storages.py
+++ b/dolphin/api/v1/storages.py
@@ -192,15 +192,13 @@ def _set_synced_if_ok(context, storage_id, resource_count):
               % storage_id
         raise exception.InvalidInput(message=msg)
     else:
-        last_update = storage['updated_at']
-        if last_update is None:
-            interval = 0
-        else:
-            current_time = datetime.now()
-            interval = (current_time - last_update).seconds
-        # If last synchronization was within 30 minutes,
-        # and the sync status is not SYNCED, it means some sync task
-        # is still running, the new sync task should not launch
+        last_update = storage['updated_at'] or storage['created_at']
+        current_time = datetime.now()
+        interval = (current_time - last_update).seconds
+        # If last synchronization was within
+        # CONF.sync_task_expiration(in seconds), and the sync status
+        # is not SYNCED, it means some sync task is still running,
+        # the new sync task should not launch
         if interval < CONF.sync_task_expiration and \
                 storage['sync_status'] != constants.SyncStatus.SYNCED:
             msg = 'Sync task is running for %s' % storage['id']


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Check the update_at value before using, because when the device has not been update yet, the value of update_at would be `None`, which can not be used to calculate the interval

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #225

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
