### PR TITLE
Example exporter for alert model

### DIFF
--- a/delfin/alert_manager/alert_processor.py
+++ b/delfin/alert_manager/alert_processor.py
@@ -18,6 +18,7 @@ from delfin import context
 from delfin import db
 from delfin import exception
 from delfin.drivers import api as driver_manager
+from delfin.exporter import base_exporter
 
 LOG = log.getLogger(__name__)
 
@@ -50,4 +51,6 @@ class AlertProcessor(object):
 
     def _export_alert_model(self, alert_model):
         """Exports the filled alert model to the export manager."""
-        LOG.info('Alert model to be exported: %s.', alert_model)
+
+        # Export to base exporter which handles dispatch for all exporters
+        base_exporter.dispatch_alert_model(alert_model)

--- a/delfin/exporter/base_exporter.py
+++ b/delfin/exporter/base_exporter.py
@@ -45,6 +45,10 @@ def _dispatch_example(ext, data):
     ext.obj.dispatch_data(data)
 
 
+def _dispatch_alert(ext, alert_model):
+    ext.obj.dispatch_alert_model(alert_model)
+
+
 # Task can call this function to report example data.
 def dispatch_example_data(data):
     """
@@ -56,6 +60,16 @@ def dispatch_example_data(data):
     export_manager.map(_dispatch_example, data)
 
 
+def dispatch_alert_model(alert_model):
+    """
+        :param alert_model: Alert model.
+        :type alert_model: dict
+        Redefine this in child classes.
+    """
+    export_manager = ExportManager().export_manager
+    export_manager.map(_dispatch_alert, alert_model)
+
+
 class BaseExampleExporter(object):
     """Base class for example exporter."""
 
@@ -63,6 +77,14 @@ class BaseExampleExporter(object):
         """Dispatch data to north bound platforms.
             :param data: Resource data.
             :type data: dict
+            Redefine this in child classes.
+        """
+        raise NotImplementedError
+
+    def dispatch_alert_model(self, alert_model):
+        """Dispatch data to north bound platforms.
+            :param alert_model: Alert model.
+            :type alert_model: dict
             Redefine this in child classes.
         """
         raise NotImplementedError

--- a/delfin/exporter/example_exporter.py
+++ b/delfin/exporter/example_exporter.py
@@ -28,6 +28,11 @@ class Example1Exporter(base_exporter.BaseExampleExporter):
         for name, value in sorted(data.items()):
             LOG.info("example1: %s = %s" % (name, value))
 
+    def dispatch_alert_model(self, alert_model):
+        LOG.info("\nExample1Exporter: Exported Alert model..")
+        for name, value in sorted(alert_model.items()):
+            LOG.info("%s = %s" % (name, value))
+
 
 class Example2Exporter(base_exporter.BaseExampleExporter):
     def __init__(self):
@@ -38,3 +43,8 @@ class Example2Exporter(base_exporter.BaseExampleExporter):
         LOG.info("Example2: report data ...")
         for name, value in sorted(data.items()):
             LOG.info("example2: %s = %s" % (name, value))
+
+    def dispatch_alert_model(self, alert_model):
+        LOG.info("\nExample2Exporter: Exported Alert model..")
+        for name, value in sorted(alert_model.items()):
+            LOG.info("%s = %s" % (name, value))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently Alert manager parses incoming traps , builds alert model.
But filled alert model is not sent/exported anywhere
This PR adds code for dispatching to base exporter and from there to example exporters
This can be used as reference while adding more exporters for alert model

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Test report:
Currently export is done to 2 example exporters, Example1Exporter and Example2Exporter
![image](https://user-images.githubusercontent.com/30930862/85733638-f9215c80-b719-11ea-9d8f-4a25fa99223b.png)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
