### PR TITLE
Support southbound device certificate verify.

### DIFF
--- a/delfin/common/config.py
+++ b/delfin/common/config.py
@@ -97,7 +97,7 @@ CONF.register_opts(global_opts)
 
 
 southbound_security_opts = [
-    cfg.BoolOpt('enable_ssl',
+    cfg.BoolOpt('enable_verify',
                 default=True,
                 help='If enable SSL certificate verification for connecting'
                      ' to southbound devices.'),

--- a/delfin/common/config.py
+++ b/delfin/common/config.py
@@ -96,6 +96,23 @@ global_opts = [
 CONF.register_opts(global_opts)
 
 
+southbound_security_opts = [
+    cfg.BoolOpt('enable_ssl',
+                default=True,
+                help='If enable SSL certificate verification for connecting'
+                     ' to southbound devices.'),
+    cfg.StrOpt('ca_path',
+               default='/usr/local/share/ca-certificates/',
+               help='The path for saving ca certificates.'),
+    cfg.BoolOpt('assert_hostname',
+                default=False,
+                help='If assert hostname or not during the process of '
+                     'certificate verification.')
+]
+
+CONF.register_opts(southbound_security_opts, group='southbound_security')
+
+
 def set_middleware_defaults():
     """Update default configuration options for oslo.middleware."""
     cors.set_defaults(

--- a/delfin/drivers/huawei/oceanstor/rest_client.py
+++ b/delfin/drivers/huawei/oceanstor/rest_client.py
@@ -50,7 +50,7 @@ class RestClient(RootRestClient):
         self.session.headers.update({
             "Connection": "keep-alive",
             "Content-Type": "application/json"})
-        if not self.enable_ssl:
+        if not self.enable_verify:
             self.session.verify = False
         else:
             LOG.debug("Enable certificate verification, ca_path: {0}".format(

--- a/delfin/drivers/security.py
+++ b/delfin/drivers/security.py
@@ -1,0 +1,85 @@
+# Copyright 2020 The SODA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import ssl
+
+import requests
+from OpenSSL.crypto import load_certificate, FILETYPE_PEM
+from oslo_config import cfg
+from oslo_log import log
+from urllib3 import PoolManager
+
+from delfin import exception
+
+LOG = log.getLogger(__name__)
+CONF = cfg.CONF
+
+
+class RootRestClient(object):
+    def __init__(self):
+        """
+        Checking the southbound security config validation.
+        As required by requests, ca_path must be a directory prepared using
+        the c_rehash tool included with OpenSSL.
+        Once new certificate added, this function can be called for update.
+        If there is a CA certificate chain, all CA certificates should be
+        included in a single file.
+        """
+        self.enable_ssl = CONF.southbound_security.enable_ssl
+        self.ca_path = CONF.southbound_security.ca_path
+        self.assert_hostname = CONF.southbound_security.assert_hostname
+
+        if self.enable_ssl:
+            if not os.path.exists(self.ca_path):
+                LOG.error("Directory {0} could not be found.".format(
+                    self.ca_path))
+                raise exception.InvalidSouthboundCAPath(self.ca_path)
+
+            suffixes = ['.pem', '.cer', '.crt', '.crl']
+            files = os.listdir(self.ca_path)
+            for file in files:
+                if not os.path.isdir(file):
+                    suf = os.path.splitext(file)[1]
+                    if suf in suffixes:
+                        fpath = self.ca_path + file
+                        cert_content = open(fpath, "rb").read()
+                        cert = load_certificate(FILETYPE_PEM, cert_content)
+                        hash_val = cert.subject_name_hash()
+                        hash_hex = hex(hash_val).strip('0x') + ".0"
+                        linkfile = self.ca_path + hash_hex
+                        if os.path.exists(linkfile):
+                            LOG.debug("Link for {0} already exist.".format(
+                                file))
+                        else:
+                            LOG.info("Create link file {0} for {1}.".format(
+                                linkfile, fpath))
+                            os.symlink(fpath, linkfile)
+
+
+class HostNameIgnoreAdapter(requests.adapters.HTTPAdapter):
+    def cert_verify(self, conn, url, verify, cert):
+        conn.assert_hostname = False
+        return super(HostNameIgnoreAdapter, self).cert_verify(
+            conn, url, verify, cert)
+    def init_poolmanager(self, connections, maxsize, block=False,
+                         **pool_kwargs):
+        self._pool_connections = connections
+        self._pool_maxsize = maxsize
+        self._pool_block = block
+        self.poolmanager = PoolManager(num_pools=connections, maxsize=maxsize,
+                                       block=block, strict=True,
+                                       ssl_version=ssl.PROTOCOL_TLSv1_2,
+                                       **pool_kwargs)
+

--- a/delfin/drivers/security.py
+++ b/delfin/drivers/security.py
@@ -37,11 +37,11 @@ class RootRestClient(object):
         If there is a CA certificate chain, all CA certificates along this
         chain should be included in a single file.
         """
-        self.enable_ssl = CONF.southbound_security.enable_ssl
+        self.enable_verify = CONF.southbound_security.enable_verify
         self.ca_path = CONF.southbound_security.ca_path
         self.assert_hostname = CONF.southbound_security.assert_hostname
 
-        if self.enable_ssl:
+        if self.enable_verify:
             if not os.path.exists(self.ca_path):
                 LOG.error("Directory {0} could not be found.".format(
                     self.ca_path))

--- a/delfin/drivers/security.py
+++ b/delfin/drivers/security.py
@@ -34,8 +34,8 @@ class RootRestClient(object):
         As required by requests, ca_path must be a directory prepared using
         the c_rehash tool included with OpenSSL.
         Once new certificate added, this function can be called for update.
-        If there is a CA certificate chain, all CA certificates should be
-        included in a single file.
+        If there is a CA certificate chain, all CA certificates along this
+        chain should be included in a single file.
         """
         self.enable_ssl = CONF.southbound_security.enable_ssl
         self.ca_path = CONF.southbound_security.ca_path
@@ -73,6 +73,7 @@ class HostNameIgnoreAdapter(requests.adapters.HTTPAdapter):
         conn.assert_hostname = False
         return super(HostNameIgnoreAdapter, self).cert_verify(
             conn, url, verify, cert)
+
     def init_poolmanager(self, connections, maxsize, block=False,
                          **pool_kwargs):
         self._pool_connections = connections
@@ -82,4 +83,3 @@ class HostNameIgnoreAdapter(requests.adapters.HTTPAdapter):
                                        block=block, strict=True,
                                        ssl_version=ssl.PROTOCOL_TLSv1_2,
                                        **pool_kwargs)
-

--- a/delfin/exception.py
+++ b/delfin/exception.py
@@ -205,3 +205,7 @@ class DuplicateExtension(DelfinException):
 
 class ImproperIPVersion(DelfinException):
     msg_fmt = _("Provided improper IP version {0}.")
+
+
+class InvalidSouthboundCAPath(DelfinException):
+    msg_fmt = _("Invalid southbound CA path: {0}.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ WebOb>=1.7.1 # MIT
 pysnmp>=4.4.11 # BSD
 redis>=3.3.8 # MIT
 PyU4V==3.1.7 # Apache-2.0
+pyopenssl==19.1.0 # Apache-2.0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently, all REST requests from delfin to southbound devices are based on http not https. This PR is to support https request.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #227 

**Special notes for your reviewer**:
In order to support https request, each driver needs to do some modification, this PR mainly to provide the common functions required by https request, and test oceanstor drivers based on it, other drivers need to modify accordingly.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. Three configure parameters are added to support this feature:
    enable_ssl: choose to enable https request or not, the default value is true.
    ca_path: the path to save CA certificates, for a CA chain, all certificates along this chain should be saved in a single file, the default value is /usr/local/share/ca-certificates/.
    assert_hostname: If asserts hostname or not during the process of certificate verification. If it's true, the target hostname will be checked if it is exactly the same as the one in the certificate, the default value is false.
```
