### PR TITLE
Update access_info model to support both REST and SSH.

### DIFF
--- a/delfin/api/schemas/access_info.py
+++ b/delfin/api/schemas/access_info.py
@@ -17,7 +17,7 @@ from delfin.api.validation import parameter_types
 update = {
     'type': 'object',
     'properties': {
-        'rest_access': {
+        'rest': {
             'type': 'object',
             'properties': {
                 'host': parameter_types.hostname_or_ip_address,
@@ -30,7 +30,7 @@ update = {
             'required': ['host', 'port', 'username', 'password'],
             'additionalProperties': False
         },
-        'ssh_access': {
+        'ssh': {
             'type': 'object',
             'properties': {
                 'host': parameter_types.hostname_or_ip_address,
@@ -57,8 +57,8 @@ update = {
         }
     },
     'anyOf': [
-        {'required': ['rest_access']},
-        {'required': ['ssh_access']}
+        {'required': ['rest']},
+        {'required': ['ssh']}
     ],
     'additionalProperties': False
 }

--- a/delfin/api/schemas/access_info.py
+++ b/delfin/api/schemas/access_info.py
@@ -17,10 +17,36 @@ from delfin.api.validation import parameter_types
 update = {
     'type': 'object',
     'properties': {
-        'host': parameter_types.hostname_or_ip_address,
-        'port': parameter_types.tcp_udp_port,
-        'username': {'type': 'string', 'minLength': 1, 'maxLength': 255},
-        'password': {'type': 'string', 'minLength': 1, 'maxLength': 255},
+        'rest_access': {
+            'type': 'object',
+            'properties': {
+                'host': parameter_types.hostname_or_ip_address,
+                'port': parameter_types.tcp_udp_port,
+                'username': {'type': 'string', 'minLength': 1,
+                             'maxLength': 255},
+                'password': {'type': 'string', 'minLength': 1,
+                             'maxLength': 255}
+            },
+            'required': ['host', 'port', 'username', 'password'],
+            'additionalProperties': False
+        },
+        'ssh_access': {
+            'type': 'object',
+            'properties': {
+                'host': parameter_types.hostname_or_ip_address,
+                'port': parameter_types.tcp_udp_port,
+                'username': {'type': 'string', 'minLength': 1,
+                             'maxLength': 255},
+                'password': {'type': 'string', 'minLength': 1,
+                             'maxLength': 255},
+                'host_key': {'type': 'string', 'minLength': 1,
+                             'maxLength': 255},
+                'host_key_type': parameter_types.host_key_type
+            },
+            'required': ['host', 'port', 'username', 'password', 'host_key',
+                         'host_key_type'],
+            'additionalProperties': False
+        },
         'extra_attributes': {
             'type': 'object',
             'patternProperties': {
@@ -30,6 +56,9 @@ update = {
             }
         }
     },
-    'required': ['username', 'password'],
+    'anyOf': [
+        {'required': ['rest_access']},
+        {'required': ['ssh_access']}
+    ],
     'additionalProperties': False
 }

--- a/delfin/api/schemas/storages.py
+++ b/delfin/api/schemas/storages.py
@@ -19,7 +19,7 @@ create = {
     'properties': {
         'vendor': {'type': 'string', 'minLength': 1, 'maxLength': 255},
         'model': {'type': 'string', 'minLength': 1, 'maxLength': 255},
-        'rest_access': {
+        'rest': {
             'type': 'object',
             'properties': {
                 'host': parameter_types.hostname_or_ip_address,
@@ -32,7 +32,7 @@ create = {
             'required': ['host', 'port', 'username', 'password'],
             'additionalProperties': False
         },
-        'ssh_access': {
+        'ssh': {
             'type': 'object',
             'properties': {
                 'host': parameter_types.hostname_or_ip_address,
@@ -60,8 +60,8 @@ create = {
     },
     'required': ['vendor', 'model'],
     'anyOf': [
-        {'required': ['rest_access']},
-        {'required': ['ssh_access']}
+        {'required': ['rest']},
+        {'required': ['ssh']}
     ],
     'additionalProperties': False
 }

--- a/delfin/api/schemas/storages.py
+++ b/delfin/api/schemas/storages.py
@@ -14,16 +14,41 @@
 
 from delfin.api.validation import parameter_types
 
-
 create = {
     'type': 'object',
     'properties': {
-        'host': parameter_types.hostname_or_ip_address,
-        'port': parameter_types.tcp_udp_port,
-        'username': {'type': 'string', 'minLength': 1, 'maxLength': 255},
-        'password': {'type': 'string', 'minLength': 1, 'maxLength': 255},
         'vendor': {'type': 'string', 'minLength': 1, 'maxLength': 255},
         'model': {'type': 'string', 'minLength': 1, 'maxLength': 255},
+        'rest_access': {
+            'type': 'object',
+            'properties': {
+                'host': parameter_types.hostname_or_ip_address,
+                'port': parameter_types.tcp_udp_port,
+                'username': {'type': 'string', 'minLength': 1,
+                             'maxLength': 255},
+                'password': {'type': 'string', 'minLength': 1,
+                             'maxLength': 255}
+            },
+            'required': ['host', 'port', 'username', 'password'],
+            'additionalProperties': False
+        },
+        'ssh_access': {
+            'type': 'object',
+            'properties': {
+                'host': parameter_types.hostname_or_ip_address,
+                'port': parameter_types.tcp_udp_port,
+                'username': {'type': 'string', 'minLength': 1,
+                             'maxLength': 255},
+                'password': {'type': 'string', 'minLength': 1,
+                             'maxLength': 255},
+                'host_key': {'type': 'string', 'minLength': 1,
+                             'maxLength': 255},
+                'host_key_type': parameter_types.host_key_type
+            },
+            'required': ['host', 'port', 'username', 'password', 'host_key',
+                         'host_key_type'],
+            'additionalProperties': False
+        },
         'extra_attributes': {
             'type': 'object',
             'patternProperties': {
@@ -33,6 +58,10 @@ create = {
             }
         }
     },
-    'required': ['host', 'port', 'username', 'password', 'vendor', 'model'],
+    'required': ['vendor', 'model'],
+    'anyOf': [
+        {'required': ['rest_access']},
+        {'required': ['ssh_access']}
+    ],
     'additionalProperties': False
 }

--- a/delfin/api/v1/access_info.py
+++ b/delfin/api/v1/access_info.py
@@ -16,6 +16,7 @@ from delfin.api import validation
 from delfin.api.common import wsgi
 from delfin.api.schemas import access_info as schema_access_info
 from delfin.api.views import access_info as access_info_viewer
+from delfin.common import constants
 from delfin.drivers import api as driverapi
 
 
@@ -37,6 +38,9 @@ class AccessInfoController(wsgi.Controller):
         """Update storage access information."""
         ctxt = req.environ.get('delfin.context')
         access_info = db.access_info_get(ctxt, id)
+        for access in constants.ACCESS_TYPE:
+            if not body.get(access):
+                body[access] = None
         access_info.update(body)
         access_info = self.driver_api.update_access_info(ctxt, access_info)
 

--- a/delfin/api/v1/storages.py
+++ b/delfin/api/v1/storages.py
@@ -76,12 +76,11 @@ class StorageController(wsgi.Controller):
         access_info_dict = body
 
         # Lock to avoid synchronous creating.
-        if access_info_dict.get('rest_access') is not None:
-            host = access_info_dict.get('rest_access').get('host')
-            port = access_info_dict.get('rest_access').get('port')
-        else:
-            host = access_info_dict.get('ssh_access').get('host')
-            port = access_info_dict.get('ssh_access').get('port')
+        for access in constants.ACCESS_TYPE:
+            if access_info_dict.get(access) is not None:
+                host = access_info_dict.get('rest').get('host')
+                port = access_info_dict.get('rest').get('port')
+                break
         lock_name = 'storage-create-' + host + '-' + str(port)
         coordination.synchronized(lock_name)
 

--- a/delfin/api/validation/parameter_types.py
+++ b/delfin/api/validation/parameter_types.py
@@ -194,5 +194,6 @@ snmp_security_level = {
 
 host_key_type = {
     'type': 'string',
-    'enum': ['dsa', 'ecdsa', 'ed25519', 'rsa'],
+    'enum': ['ssh-ed25519', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384',
+             'ecdsa-sha2-nistp521', 'ssh-rsa', 'ssh-dss'],
 }

--- a/delfin/api/validation/parameter_types.py
+++ b/delfin/api/validation/parameter_types.py
@@ -191,3 +191,8 @@ snmp_security_level = {
     'type': 'string',
     'enum': ['AuthPriv', 'AuthNoPriv', 'NoAuthNoPriv'],
 }
+
+host_key_type = {
+    'type': 'string',
+    'enum': ['dsa', 'ecdsa', 'ed25519', 'rsa'],
+}

--- a/delfin/api/views/access_info.py
+++ b/delfin/api/views/access_info.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from delfin.common import constants
+
 
 class ViewBuilder(object):
 
     def show(self, access_info):
         access_info_dict = access_info.to_dict()
-        access_info_dict.pop('password', None)
+        for access in constants.ACCESS_TYPE:
+            if access_info.get(access):
+                access_info[access].pop('password', None)
         return access_info_dict

--- a/delfin/common/constants.py
+++ b/delfin/common/constants.py
@@ -20,6 +20,10 @@ from enum import IntEnum
 DB_MAX_INT = 0x7FFFFFFF
 
 
+# Valid access type supported currently.
+ACCESS_TYPE = ['rest_access', 'ssh_access']
+
+
 # Custom fields for Delfin objects
 class StorageStatus(object):
     NORMAL = 'normal'

--- a/delfin/common/constants.py
+++ b/delfin/common/constants.py
@@ -21,7 +21,7 @@ DB_MAX_INT = 0x7FFFFFFF
 
 
 # Valid access type supported currently.
-ACCESS_TYPE = ['rest_access', 'ssh_access']
+ACCESS_TYPE = ['rest', 'ssh']
 
 
 # Custom fields for Delfin objects

--- a/delfin/db/sqlalchemy/models.py
+++ b/delfin/db/sqlalchemy/models.py
@@ -52,10 +52,8 @@ class AccessInfo(BASE, DelfinBase):
     storage_id = Column(String(36), primary_key=True)
     vendor = Column(String(255))
     model = Column(String(255))
-    host = Column(String(255))
-    port = Column(String(255))
-    username = Column(String(255))
-    password = Column(String(255))
+    rest_access = Column(JsonEncodedDict)
+    ssh_access = Column(JsonEncodedDict)
     extra_attributes = Column(JsonEncodedDict)
 
 

--- a/delfin/db/sqlalchemy/models.py
+++ b/delfin/db/sqlalchemy/models.py
@@ -52,8 +52,8 @@ class AccessInfo(BASE, DelfinBase):
     storage_id = Column(String(36), primary_key=True)
     vendor = Column(String(255))
     model = Column(String(255))
-    rest_access = Column(JsonEncodedDict)
-    ssh_access = Column(JsonEncodedDict)
+    rest = Column(JsonEncodedDict)
+    ssh = Column(JsonEncodedDict)
     extra_attributes = Column(JsonEncodedDict)
 
 

--- a/delfin/drivers/dell_emc/vmax/client.py
+++ b/delfin/drivers/dell_emc/vmax/client.py
@@ -28,9 +28,16 @@ SUPPORTED_VERSION = '90'
 class VMAXClient(object):
     """ Client class for communicating with VMAX storage """
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         self.conn = None
         self.array_id = None
+        rest_access = kwargs.get('rest_access')
+        if rest_access is None:
+            raise exception.InvalidInput('Input rest_access is missing')
+        self.rest_host = rest_access.get('host', 'localhost')
+        self.rest_port = rest_access.get('port', '8088')
+        self.rest_username = rest_access.get('username')
+        self.rest_password = rest_access.get('password')
 
     def __del__(self):
         # De-initialize session
@@ -49,12 +56,12 @@ class VMAXClient(object):
             # Initialise PyU4V connection to VMAX
             self.conn = PyU4V.U4VConn(
                 u4v_version=SUPPORTED_VERSION,
-                server_ip=access_info['host'],
-                port=access_info['port'],
+                server_ip=self.rest_host,
+                port=self.rest_port,
                 verify=False,
                 array_id=self.array_id,
-                username=access_info['username'],
-                password=access_info['password'])
+                username=self.rest_username,
+                password=self.rest_password)
 
         except Exception as err:
             msg = "Failed to connect to VMAX: {}".format(err)

--- a/delfin/drivers/dell_emc/vmax/client.py
+++ b/delfin/drivers/dell_emc/vmax/client.py
@@ -31,11 +31,11 @@ class VMAXClient(object):
     def __init__(self, **kwargs):
         self.conn = None
         self.array_id = None
-        rest_access = kwargs.get('rest_access')
+        rest_access = kwargs.get('rest')
         if rest_access is None:
             raise exception.InvalidInput('Input rest_access is missing')
-        self.rest_host = rest_access.get('host', 'localhost')
-        self.rest_port = rest_access.get('port', '8088')
+        self.rest_host = rest_access.get('host')
+        self.rest_port = rest_access.get('port')
         self.rest_username = rest_access.get('username')
         self.rest_password = rest_access.get('password')
 

--- a/delfin/drivers/dell_emc/vmax/vmax.py
+++ b/delfin/drivers/dell_emc/vmax/vmax.py
@@ -28,7 +28,7 @@ class VMAXStorageDriver(driver.StorageDriver):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.client = client.VMAXClient()
+        self.client = client.VMAXClient(**kwargs)
         self._init_vmax(kwargs)
 
     def _init_vmax(self, access_info):

--- a/delfin/drivers/helper.py
+++ b/delfin/drivers/helper.py
@@ -17,24 +17,36 @@ from oslo_log import log
 from delfin import cryptor
 from delfin import db
 from delfin import exception
+from delfin.common import constants
 from delfin.i18n import _
 
 LOG = log.getLogger(__name__)
 
 
+def encrypt_password(context, access_info):
+    for access in constants.ACCESS_TYPE:
+        if access_info.get(access):
+            access_info[access]['password'] = cryptor.encode(
+                access_info[access]['password'])
+
+
 def get_access_info(context, storage_id):
     access_info = db.access_info_get(context, storage_id)
     access_info_dict = access_info.to_dict()
-    access_info_dict['password'] = cryptor.decode(access_info_dict['password'])
+    for access in constants.ACCESS_TYPE:
+        if access_info.get(access):
+            access_info[access]['password'] = cryptor.decode(
+                access_info[access]['password'])
     return access_info_dict
 
 
 def create_access_info(context, access_info):
-    access_info['password'] = cryptor.encode(access_info['password'])
+    encrypt_password(context, access_info)
     return db.access_info_create(context, access_info)
 
 
 def update_access_info(context, storage_id, access_info):
+    encrypt_password(context, access_info)
     return db.access_info_update(context,
                                  storage_id,
                                  access_info)

--- a/delfin/drivers/huawei/oceanstor/rest_client.py
+++ b/delfin/drivers/huawei/oceanstor/rest_client.py
@@ -32,11 +32,11 @@ class RestClient(object):
 
     def __init__(self, **kwargs):
 
-        rest_access = kwargs.get('rest_access')
+        rest_access = kwargs.get('rest')
         if rest_access is None:
             raise exception.InvalidInput('Input rest_access is missing')
-        self.rest_host = rest_access.get('host', 'localhost')
-        self.rest_port = rest_access.get('port', '8088')
+        self.rest_host = rest_access.get('host')
+        self.rest_port = rest_access.get('port')
         self.rest_username = rest_access.get('username')
         self.rest_password = rest_access.get('password')
         # Lists of addresses to try, for authorization

--- a/delfin/drivers/huawei/oceanstor/rest_client.py
+++ b/delfin/drivers/huawei/oceanstor/rest_client.py
@@ -32,13 +32,17 @@ class RestClient(object):
 
     def __init__(self, **kwargs):
 
-        host = kwargs.get('host', 'localhost')
-        port = kwargs.get('port', '8088')
+        rest_access = kwargs.get('rest_access')
+        if rest_access is None:
+            raise exception.InvalidInput('Input rest_access is missing')
+        self.rest_host = rest_access.get('host', 'localhost')
+        self.rest_port = rest_access.get('port', '8088')
+        self.rest_username = rest_access.get('username')
+        self.rest_password = rest_access.get('password')
         # Lists of addresses to try, for authorization
         self.san_address = [
-            'https://' + host + ':' + port + '/deviceManager/rest/']
-        self.san_user = kwargs.get('username')
-        self.san_password = kwargs.get('password')
+            'https://' + self.rest_host + ':' + self.rest_port +
+            '/deviceManager/rest/']
         self.session = None
         self.url = None
         self.device_id = None
@@ -105,8 +109,8 @@ class RestClient(object):
         device_id = None
         for item_url in self.san_address:
             url = item_url + "xx/sessions"
-            data = {"username": self.san_user,
-                    "password": self.san_password,
+            data = {"username": self.rest_username,
+                    "password": self.rest_password,
                     "scope": "0"}
             self.init_http_head()
             result = self.do_call(url, data, 'POST',

--- a/delfin/tests/unit/api/fakes.py
+++ b/delfin/tests/unit/api/fakes.py
@@ -146,7 +146,7 @@ def fake_access_info_get_all(context, marker=None, limit=None, sort_keys=None,
             'storage_id': '5f5c806d-2e65-473c-b612-345ef43f0642',
             'model': 'fake_driver',
             'vendor': 'fake_storage',
-            'rest_access': {
+            'rest': {
                 'host': '10.0.0.76',
                 'port': '1234',
                 'username': 'admin',
@@ -248,7 +248,7 @@ def fake_access_info_show(context, storage_id):
     access_info.created_at = '2020-06-15T09:50:31.698956'
     access_info.vendor = 'fake_storage'
     access_info.model = 'fake_driver'
-    access_info.rest_access = {
+    access_info.rest = {
         'host': '10.0.0.0',
         'username': 'admin',
         'password': 'YWJjZA==',
@@ -267,7 +267,7 @@ def fake_update_access_info(self, context, access_info):
     access_info.created_at = '2020-06-15T09:50:31.698956'
     access_info.vendor = 'fake_storage'
     access_info.model = 'fake_driver'
-    access_info.rest_access = {
+    access_info.rest = {
         'host': '10.0.0.0',
         'username': 'admin_modified',
         'password': 'YWJjZA==',

--- a/delfin/tests/unit/api/fakes.py
+++ b/delfin/tests/unit/api/fakes.py
@@ -143,14 +143,17 @@ def fake_access_info_get_all(context, marker=None, limit=None, sort_keys=None,
     return [
         {
             'created_at': "2020-06-09T08:59:48.710890",
-            'model': 'fake_driver',
             'storage_id': '5f5c806d-2e65-473c-b612-345ef43f0642',
-            'host': '10.0.0.76',
+            'model': 'fake_driver',
+            'vendor': 'fake_storage',
+            'rest_access': {
+                'host': '10.0.0.76',
+                'port': '1234',
+                'username': 'admin',
+                'password': b'YWJjZA=='
+            },
             'extra_attributes': {'array_id': '0001234567891'},
-            'password': b'YWJjZA==', 'port': '1234',
-            'updated_at': None,
-            'username': 'admin',
-            'vendor': 'fake_storage'
+            'updated_at': None
         }
     ]
 
@@ -237,7 +240,7 @@ def alert_source_get_exception(ctx, storage_id):
     raise exception.AlertSourceNotFound('abcd-1234-5678')
 
 
-def fake_access_info__show(context, storage_id):
+def fake_access_info_show(context, storage_id):
     access_info = models.AccessInfo()
 
     access_info.updated_at = '2020-06-15T09:50:31.698956'
@@ -245,10 +248,12 @@ def fake_access_info__show(context, storage_id):
     access_info.created_at = '2020-06-15T09:50:31.698956'
     access_info.vendor = 'fake_storage'
     access_info.model = 'fake_driver'
-    access_info.host = '10.0.0.0'
-    access_info.username = 'admin'
-    access_info.password = 'YWJjZA=='
-    access_info.port = '1234'
+    access_info.rest_access = {
+        'host': '10.0.0.0',
+        'username': 'admin',
+        'password': 'YWJjZA==',
+        'port': 1234
+    }
     access_info.extra_attributes = {'array_id': '0001234567897'}
 
     return access_info
@@ -262,10 +267,12 @@ def fake_update_access_info(self, context, access_info):
     access_info.created_at = '2020-06-15T09:50:31.698956'
     access_info.vendor = 'fake_storage'
     access_info.model = 'fake_driver'
-    access_info.host = '10.0.0.0'
-    access_info.username = 'admin_modified'
-    access_info.password = 'YWJjZA=='
-    access_info.port = '1234'
+    access_info.rest_access = {
+        'host': '10.0.0.0',
+        'username': 'admin_modified',
+        'password': 'YWJjZA==',
+        'port': 1234
+    }
     access_info.extra_attributes = {'array_id': '0001234567897'}
 
     return access_info

--- a/delfin/tests/unit/api/v1/test_access_info.py
+++ b/delfin/tests/unit/api/v1/test_access_info.py
@@ -42,12 +42,12 @@ class TestAccessInfoController(test.TestCase):
             "model": "fake_driver",
             "vendor": "fake_storage",
             "storage_id": "865ffd4d-f1f7-47de-abc3-5541ef44d0c1",
-            "rest_access": {
+            "rest": {
                 "host": "10.0.0.0",
                 "port": 1234,
                 "username": "admin"
             },
-            "ssh_access": None,
+            "ssh": None,
             "extra_attributes": {
                 "array_id": "0001234567897"
             },
@@ -77,7 +77,7 @@ class TestAccessInfoController(test.TestCase):
             mock.Mock(return_value=fake_access_info))
 
         body = {
-            'rest_access': {
+            'rest': {
                 'username': 'admin_modified',
                 'password': 'abcd_modified',
                 'host': '10.0.0.0',
@@ -93,12 +93,12 @@ class TestAccessInfoController(test.TestCase):
             "model": "fake_driver",
             "vendor": "fake_storage",
             "storage_id": "865ffd4d-f1f7-47de-abc3-5541ef44d0c1",
-            "rest_access": {
+            "rest": {
                 "username": "admin_modified",
                 "host": "10.0.0.0",
                 "port": 1234
             },
-            "ssh_access": None,
+            "ssh": None,
             "extra_attributes": {
                 "array_id": "0001234567897"
             },

--- a/delfin/tests/unit/api/v1/test_access_info.py
+++ b/delfin/tests/unit/api/v1/test_access_info.py
@@ -32,7 +32,7 @@ class TestAccessInfoController(test.TestCase):
     def test_show(self):
         self.mock_object(
             db, 'access_info_get',
-            fakes.fake_access_info__show)
+            fakes.fake_access_info_show)
         req = fakes.HTTPRequest.blank(
             '/storages/865ffd4d-f1f7-47de-abc3-5541ef44d0c1/access-info')
 
@@ -42,14 +42,17 @@ class TestAccessInfoController(test.TestCase):
             "model": "fake_driver",
             "vendor": "fake_storage",
             "storage_id": "865ffd4d-f1f7-47de-abc3-5541ef44d0c1",
-            "port": "1234",
-            "host": "10.0.0.0",
+            "rest_access": {
+                "host": "10.0.0.0",
+                "port": 1234,
+                "username": "admin"
+            },
+            "ssh_access": None,
             "extra_attributes": {
                 "array_id": "0001234567897"
             },
             "created_at": "2020-06-15T09:50:31.698956",
-            "updated_at": "2020-06-15T09:50:31.698956",
-            "username": "admin"
+            "updated_at": "2020-06-15T09:50:31.698956"
         }
 
         self.assertDictEqual(expctd_dict, res_dict)
@@ -66,7 +69,7 @@ class TestAccessInfoController(test.TestCase):
     def test_access_info_update(self):
         self.mock_object(
             db, 'access_info_get',
-            fakes.fake_access_info__show)
+            fakes.fake_access_info_show)
 
         fake_access_info = fakes.fake_update_access_info(None, None, None)
         self.mock_object(
@@ -74,11 +77,13 @@ class TestAccessInfoController(test.TestCase):
             mock.Mock(return_value=fake_access_info))
 
         body = {
-            'username': 'admin_modified',
-            'extra_attributes': {'array_id': '0001234567891'},
-            'password': 'abcd_modified',
-            'host': '10.0.0.0',
-            'port': 1234
+            'rest_access': {
+                'username': 'admin_modified',
+                'password': 'abcd_modified',
+                'host': '10.0.0.0',
+                'port': 1234
+            },
+            'extra_attributes': {'array_id': '0001234567891'}
         }
         req = fakes.HTTPRequest.blank(
             '/storages/865ffd4d-f1f7-47de-abc3-5541ef44d0c1/access-info')
@@ -88,13 +93,16 @@ class TestAccessInfoController(test.TestCase):
             "model": "fake_driver",
             "vendor": "fake_storage",
             "storage_id": "865ffd4d-f1f7-47de-abc3-5541ef44d0c1",
-            "port": "1234",
-            "host": "10.0.0.0",
+            "rest_access": {
+                "username": "admin_modified",
+                "host": "10.0.0.0",
+                "port": 1234
+            },
+            "ssh_access": None,
             "extra_attributes": {
                 "array_id": "0001234567897"
             },
             "created_at": "2020-06-15T09:50:31.698956",
-            "updated_at": "2020-06-15T09:50:31.698956",
-            "username": "admin_modified"
+            "updated_at": "2020-06-15T09:50:31.698956"
         }
         self.assertDictEqual(expctd_dict, res_dict)

--- a/delfin/tests/unit/api/v1/test_storages.py
+++ b/delfin/tests/unit/api/v1/test_storages.py
@@ -199,11 +199,13 @@ class TestStorageController(test.TestCase):
         body = {
             'model': 'fake_driver',
             'vendor': 'fake_storage',
-            'username': 'admin',
-            'extra_attributes': {'array_id': '0001234567891'},
-            'password': 'abcd',
-            'host': '10.0.0.76',
-            'port': 1234
+            'rest_access': {
+                'username': 'admin',
+                'password': 'abcd',
+                'host': '10.0.0.76',
+                'port': 1234
+            },
+            'extra_attributes': {'array_id': '0001234567891'}
         }
         req = fakes.HTTPRequest.blank(
             '/storages')
@@ -256,11 +258,13 @@ class TestStorageController(test.TestCase):
         body = {
             'model': 'fake_driver',
             'vendor': 'fake_storage',
-            'username': 'admin',
-            'extra_attributes': {'array_id': '0001234567891'},
-            'password': 'abcd',
-            'host': '10.0.0.76',
-            'port': 1234
+            'rest_access': {
+                'username': 'admin',
+                'password': 'abcd',
+                'host': '10.0.0.76',
+                'port': 1234
+            },
+            'extra_attributes': {'array_id': '0001234567891'}
         }
         req = fakes.HTTPRequest.blank(
             '/storages')

--- a/delfin/tests/unit/api/v1/test_storages.py
+++ b/delfin/tests/unit/api/v1/test_storages.py
@@ -199,7 +199,7 @@ class TestStorageController(test.TestCase):
         body = {
             'model': 'fake_driver',
             'vendor': 'fake_storage',
-            'rest_access': {
+            'rest': {
                 'username': 'admin',
                 'password': 'abcd',
                 'host': '10.0.0.76',
@@ -258,7 +258,7 @@ class TestStorageController(test.TestCase):
         body = {
             'model': 'fake_driver',
             'vendor': 'fake_storage',
-            'rest_access': {
+            'rest': {
                 'username': 'admin',
                 'password': 'abcd',
                 'host': '10.0.0.76',

--- a/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
+++ b/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
@@ -29,7 +29,7 @@ VMAX_STORAGE_CONF = {
     "storage_id": "12345",
     "vendor": "dell_emc",
     "model": "vmax",
-    "rest_access": {
+    "rest": {
         "host": "10.0.0.1",
         "port": "8443",
         "username": "user",
@@ -58,7 +58,7 @@ class TestVMAXStorageDriver(TestCase):
             self.assertEqual(driver.client.array_id, "00112233")
 
         invalid_input = {
-            'rest_access': {
+            'rest': {
                 "host": "10.0.0.1",
                 "port": "8443",
                 "username": "user",

--- a/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
+++ b/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
@@ -27,12 +27,14 @@ class Request:
 
 VMAX_STORAGE_CONF = {
     "storage_id": "12345",
-    "host": "10.0.0.1",
-    "port": "8443",
-    "username": "user",
-    "password": "pass",
     "vendor": "dell_emc",
     "model": "vmax",
+    "rest_access": {
+        "host": "10.0.0.1",
+        "port": "8443",
+        "username": "user",
+        "password": "pass"
+    },
     "extra_attributes": {
         "array_id": "00112233"
     }
@@ -55,7 +57,14 @@ class TestVMAXStorageDriver(TestCase):
             self.assertEqual(driver.storage_id, "12345")
             self.assertEqual(driver.client.array_id, "00112233")
 
-        invalid_input = {'extra_attributes': {}}
+        invalid_input = {
+            'rest_access': {
+                "host": "10.0.0.1",
+                "port": "8443",
+                "username": "user",
+                "password": "pass"
+            },
+            'extra_attributes': {}}
         with self.assertRaises(Exception) as exc:
             VMAXStorageDriver(**invalid_input)
         self.assertIn('Input array_id is missing', str(exc.exception))

--- a/delfin/tests/unit/drivers/huawei/oceanstor/test_oceanstor.py
+++ b/delfin/tests/unit/drivers/huawei/oceanstor/test_oceanstor.py
@@ -29,12 +29,14 @@ class Request:
 
 ACCESS_INFO = {
     "storage_id": "12345",
-    "host": "10.0.0.1",
-    "port": "8443",
-    "username": "user",
-    "password": "pass",
     "vendor": "dell_emc",
     "model": "vmax",
+    "rest_access": {
+        "host": "10.0.0.1",
+        "port": "8443",
+        "username": "user",
+        "password": "pass",
+    },
     "extra_attributes": {
         "array_id": "00112233"
     }

--- a/delfin/tests/unit/drivers/huawei/oceanstor/test_oceanstor.py
+++ b/delfin/tests/unit/drivers/huawei/oceanstor/test_oceanstor.py
@@ -31,7 +31,7 @@ ACCESS_INFO = {
     "storage_id": "12345",
     "vendor": "dell_emc",
     "model": "vmax",
-    "rest_access": {
+    "rest": {
         "host": "10.0.0.1",
         "port": "8443",
         "username": "user",

--- a/delfin/tests/unit/drivers/test_api.py
+++ b/delfin/tests/unit/drivers/test_api.py
@@ -34,12 +34,14 @@ class Request:
 
 ACCESS_INFO = {
     "storage_id": "12345",
-    "host": "10.0.0.1",
-    "port": "8443",
-    "username": "user",
-    "password": "pass",
     "vendor": "fake_storage",
     "model": "fake_driver",
+    "rest_access": {
+        "host": "10.0.0.1",
+        "port": "8443",
+        "username": "user",
+        "password": "pass"
+    },
     "extra_attributes": {
         "array_id": "00112233"
     }
@@ -136,7 +138,7 @@ class TestDriverAPI(TestCase):
                                 mock_storage):
         storage = copy.deepcopy(STORAGE)
         access_info_new = copy.deepcopy(ACCESS_INFO)
-        access_info_new['username'] = 'new_user'
+        access_info_new['rest_access']['username'] = 'new_user'
 
         mock_storage_get.return_value = storage
         mock_access_info_update.return_value = access_info_new
@@ -155,7 +157,7 @@ class TestDriverAPI(TestCase):
         mock_storage_update.assert_called_with(
             context, storage_id, storage)
 
-        access_info_new['password'] = mock.Mock()
+        access_info_new['rest_access']['password'] = mock.Mock()
         self.assertDictEqual(access_info_new, updated)
 
         # Case: Wrong storage serial number

--- a/delfin/tests/unit/drivers/test_api.py
+++ b/delfin/tests/unit/drivers/test_api.py
@@ -36,7 +36,7 @@ ACCESS_INFO = {
     "storage_id": "12345",
     "vendor": "fake_storage",
     "model": "fake_driver",
-    "rest_access": {
+    "rest": {
         "host": "10.0.0.1",
         "port": "8443",
         "username": "user",
@@ -138,7 +138,7 @@ class TestDriverAPI(TestCase):
                                 mock_storage):
         storage = copy.deepcopy(STORAGE)
         access_info_new = copy.deepcopy(ACCESS_INFO)
-        access_info_new['rest_access']['username'] = 'new_user'
+        access_info_new['rest']['username'] = 'new_user'
 
         mock_storage_get.return_value = storage
         mock_access_info_update.return_value = access_info_new
@@ -157,7 +157,7 @@ class TestDriverAPI(TestCase):
         mock_storage_update.assert_called_with(
             context, storage_id, storage)
 
-        access_info_new['rest_access']['password'] = mock.Mock()
+        access_info_new['rest']['password'] = mock.Mock()
         self.assertDictEqual(access_info_new, updated)
 
         # Case: Wrong storage serial number

--- a/openapi-spec/swagger.yaml
+++ b/openapi-spec/swagger.yaml
@@ -995,14 +995,143 @@ components:
           format: date-time
           readOnly: true
           example: '2017-07-10T14:36:58.014Z'
-    StorageBackendRegistry:
+    RestAccessInfoRegistry:
       required:
         - host
-        - model
-        - password
         - port
         - username
+        - password
+      type: object
+      properties:
+        host:
+          type: string
+          example: 10.0.0.1
+        port:
+          type: string
+          example: "8008"
+        username:
+          type: string
+          example: admin
+        password:
+          type: string
+    SSHAccessInfoRegistry:
+      required:
+        - host
+        - port
+        - username
+        - password
+        - pub_key
+        - pub_key_type
+      type: object
+      properties:
+        host:
+          type: string
+          example: '10.0.0.1'
+        port:
+          type: string
+          example: '22'
+        username:
+          type: string
+          example: admin
+        password:
+          type: string
+        pub_key:
+          type: string
+          example: '73:d8:34:18:70:2a:ae:d8:1c:a5:44:40:ef:50:d0:63'
+        pub_key_type:
+          type: string
+          enum: ['ed25519', 'ecdsa', 'rsa']
+    RestAccessInfoUpdate:
+      required:
+        - username
+        - password
+      type: object
+      properties:
+        host:
+          type: string
+          example: 10.0.0.1
+        port:
+          type: string
+          example: "8008"
+        username:
+          type: string
+          example: admin
+        password:
+          type: string
+    SSHAccessInfoUpdate:
+      required:
+        - username
+        - password
+      type: object
+      properties:
+        host:
+          type: string
+          example: '10.0.0.1'
+        port:
+          type: string
+          example: '22'
+        username:
+          type: string
+          example: admin
+        password:
+          type: string
+        pub_key:
+          type: string
+          example: '73:d8:34:18:70:2a:ae:d8:1c:a5:44:40:ef:50:d0:63'
+        pub_key_type:
+          type: string
+          enum: ['ed25519', 'ecdsa', 'rsa']
+    RestAccessInfoResponse:
+      required:
+        - host
+        - port
+        - username
+      type: object
+      properties:
+        host:
+          type: string
+          example: 10.0.0.1
+        port:
+          type: string
+          example: "8008"
+        username:
+          type: string
+          example: admin
+        password:
+          type: string
+    SSHAccessInfoResponse:
+      required:
+        - host
+        - port
+        - username
+        - pub_key
+        - pub_key_type
+      type: object
+      properties:
+        host:
+          type: string
+          example: '10.0.0.1'
+        port:
+          type: string
+          example: '22'
+        username:
+          type: string
+          example: admin
+        password:
+          type: string
+        pub_key:
+          type: string
+          example: '73:d8:34:18:70:2a:ae:d8:1c:a5:44:40:ef:50:d0:63'
+        pub_key_type:
+          type: string
+          enum: ['ed25519', 'ecdsa', 'rsa']
+    StorageBackendRegistry:
+      required:
+        - model
         - vendor
+      anyOf:
+        - $ref: '#/components/schemas/RestAccessInfoRegistry'
+        - $ref: '#/components/schemas/SSHAccessInfoRegistry'
       type: object
       properties:
         name:
@@ -1017,17 +1146,10 @@ components:
         model:
           type: string
           example: vmax
-        host:
-          type: string
-          example: 10.0.0.1
-        port:
-          type: string
-          example: '8443'
-        username:
-          type: string
-          example: admin
-        password:
-          type: string
+        rest_access:
+          $ref: '#/components/schemas/RestAccessInfoRegistry'
+        ssh_access:
+          $ref: '#/components/schemas/SSHAccessInfoRegistry'
         extra_attributes:
           type: object
           additionalProperties:
@@ -1035,21 +1157,15 @@ components:
           example:
             array_id: 00002554321
     StorageBackendRegistryUpdate:
-      required:
-        - password
-        - username
+      anyOf:
+        - $ref: '#/components/schemas/RestAccessInfoUpdate'
+        - $ref: '#/components/schemas/SSHAccessInfoUpdate'
       type: object
       properties:
-        host:
-          type: string
-          example: 10.0.0.1
-        username:
-          type: string
-          example: admin
-        password:
-          type: string
-        port:
-          type: string
+        rest_access:
+          $ref: '#/components/schemas/RestAccessInfoUpdate'
+        ssh_access:
+          $ref: '#/components/schemas/SSHAccessInfoUpdate'
         extra_attributes:
           type: object
           additionalProperties:
@@ -1109,12 +1225,10 @@ components:
       properties:
         id:
           type: string
-        username:
-          type: string
-          example: admin
-        port:
-          type: string
-          example: '1234'
+        rest_access:
+          $ref: '#/components/schemas/RestAccessInfoResponse'
+        ssh_access:
+          $ref: '#/components/schemas/SSHAccessInfoResponse'
         vendor:
           type: string
           example: dellemc

--- a/openapi-spec/swagger.yaml
+++ b/openapi-spec/swagger.yaml
@@ -1130,9 +1130,9 @@ components:
         model:
           type: string
           example: vmax
-        rest_access:
+        rest:
           $ref: '#/components/schemas/RestAccessInfoRegistry'
-        ssh_access:
+        ssh:
           $ref: '#/components/schemas/SSHAccessInfoRegistry'
         extra_attributes:
           type: object
@@ -1146,9 +1146,9 @@ components:
         - $ref: '#/components/schemas/SSHAccessInfoUpdate'
       type: object
       properties:
-        rest_access:
+        rest:
           $ref: '#/components/schemas/RestAccessInfoUpdate'
-        ssh_access:
+        ssh:
           $ref: '#/components/schemas/SSHAccessInfoUpdate'
         extra_attributes:
           type: object
@@ -1209,9 +1209,9 @@ components:
       properties:
         id:
           type: string
-        rest_access:
+        rest:
           $ref: '#/components/schemas/RestAccessInfoResponse'
-        ssh_access:
+        ssh:
           $ref: '#/components/schemas/SSHAccessInfoResponse'
         vendor:
           type: string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Some drivers, HPE 3PAR for example, need both REST and SSH at the same time to manage the storage device, but currently, our access_info model can only support one type, so we need to take this scenario into consideration and update it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #245 

**Special notes for your reviewer**:
This is the first PR for SSH support. After this PR, left PRs include:
1. Add API to get the public key of the device;
2. Drivers support SSH.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
