### PR TITLE
Modify the constant type of sync status

### DIFF
--- a/delfin/common/constants.py
+++ b/delfin/common/constants.py
@@ -14,8 +14,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from enum import IntEnum
-
 # The maximum value a signed INT type may have
 DB_MAX_INT = 0x7FFFFFFF
 
@@ -51,7 +49,7 @@ class StorageType(object):
     ALL = (BLOCK, FILE)
 
 
-class SyncStatus(IntEnum):
+class SyncStatus(object):
     SYNCED = 0
 
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
No need to use _IntEnum_ for SyncStatus because we only have one value of it.
On another hand, _IntEnum_ is ok for sqlite, but some database(MySQL, Zenith) does not recognize this type, so this should be modified to support more type of database.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
