### PR TITLE
Adding raw_capacity and subscribed capacity in  VMAX driver

### DIFF
--- a/delfin/drivers/dell_emc/vmax/client.py
+++ b/delfin/drivers/dell_emc/vmax/client.py
@@ -103,7 +103,7 @@ class VMAXClient(object):
                 srp_cap = pool_info['srp_capacity']
                 total_cap = srp_cap['usable_total_tb'] * units.Ti
                 used_cap = srp_cap['usable_used_tb'] * units.Ti
-
+                subscribed_cap = srp_cap['subscribed_total_tb'] * units.Ti
                 p = {
                     "name": pool,
                     "storage_id": storage_id,
@@ -114,6 +114,7 @@ class VMAXClient(object):
                     "total_capacity": int(total_cap),
                     "used_capacity": int(used_cap),
                     "free_capacity": int(total_cap - used_cap),
+                    "subscribed_capacity": int(subscribed_cap),
                 }
                 pool_list.append(p)
 

--- a/delfin/drivers/dell_emc/vmax/client.py
+++ b/delfin/drivers/dell_emc/vmax/client.py
@@ -84,7 +84,7 @@ class VMAXClient(object):
             uri = "/" + SUPPORTED_VERSION \
                   + "/sloprovisioning/symmetrix/" + self.array_id
             storage_info = self.conn.common.get_request(uri, "")
-            return storage_info['system_capacity']
+            return storage_info
         except Exception as err:
             msg = "Failed to get capacity from VMAX: {}".format(err)
             LOG.error(msg)

--- a/delfin/drivers/dell_emc/vmax/vmax.py
+++ b/delfin/drivers/dell_emc/vmax/vmax.py
@@ -35,14 +35,17 @@ class VMAXStorageDriver(driver.StorageDriver):
         self.client.init_connection(access_info)
 
     def get_storage(self, context):
-
         # Get the VMAX model
         model = self.client.get_model()
 
         # Get Storage details for capacity info
         storg_info = self.client.get_storage_capacity()
-        total_cap = storg_info.get('usable_total_tb')
-        used_cap = storg_info.get('usable_used_tb')
+        system_capacity = storg_info['system_capacity']
+        physical_capacity = storg_info['physicalCapacity']
+        total_cap = system_capacity.get('usable_total_tb')
+        used_cap = system_capacity.get('usable_used_tb')
+        subscribed_cap = system_capacity.get('subscribed_total_tb')
+        total_raw = physical_capacity.get('total_capacity_gb')
         free_cap = total_cap - used_cap
 
         storage = {
@@ -55,7 +58,9 @@ class VMAXStorageDriver(driver.StorageDriver):
             'location': '',
             'total_capacity': int(total_cap * units.Ti),
             'used_capacity': int(used_cap * units.Ti),
-            'free_capacity': int(free_cap * units.Ti)
+            'free_capacity': int(free_cap * units.Ti),
+            'raw_capacity': int(total_raw * units.Gi),
+            'subscribed_capacity': int(subscribed_cap * units.Ti)
         }
         LOG.info("get_storage(), successfully retrieved storage details")
         return storage

--- a/delfin/tests/unit/api/fakes.py
+++ b/delfin/tests/unit/api/fakes.py
@@ -72,7 +72,9 @@ def fake_storages_get_all(context, marker=None, limit=None, sort_keys=None,
             "description": "it is a fake driver.",
             "serial_number": "2102453JPN12KA0000113",
             "used_capacity": 3126,
-            "total_capacity": 1048576
+            "total_capacity": 1048576,
+            'raw_capacity': 1610612736000,
+            'subscribed_capacity': 219902325555200
         },
         {
             "id": "277a1d8f-a36e-423e-bdd9-db154f32c289",
@@ -89,7 +91,10 @@ def fake_storages_get_all(context, marker=None, limit=None, sort_keys=None,
             "description": "it is a fake driver.",
             "serial_number": "2102453JPN12KA0000112",
             "used_capacity": 3126,
-            "total_capacity": 1048576
+            "total_capacity": 1048576,
+            'raw_capacity': 1610612736000,
+            'subscribed_capacity': 219902325555200
+
         }
     ]
 
@@ -113,7 +118,9 @@ def fake_storages_get_all_with_filter(
             "description": "it is a fake driver.",
             "serial_number": "2102453JPN12KA0000113",
             "used_capacity": 3126,
-            "total_capacity": 1048576
+            "total_capacity": 1048576,
+            'raw_capacity': 1610612736000,
+            'subscribed_capacity': 219902325555200
         }
     ]
 
@@ -134,7 +141,9 @@ def fake_storages_show(context, storage_id):
         "description": "it is a fake driver.",
         "serial_number": "2102453JPN12KA0000113",
         "used_capacity": 3126,
-        "total_capacity": 1048576
+        "total_capacity": 1048576,
+        'raw_capacity': 1610612736000,
+        'subscribed_capacity': 219902325555200
     }
 
 
@@ -358,7 +367,8 @@ def fake_storage_pool_get_all(context, marker=None,
             "storage_type": "block",
             "total_capacity": 26300318136401,
             "used_capacity": 19054536509358,
-            "free_capacity": 7245781627043
+            "free_capacity": 7245781627043,
+            'subscribed_capacity': 219902325555200
         }
     ]
 
@@ -376,5 +386,6 @@ def fake_storage_pool_show(context, storage_pool_id):
         "storage_type": "block",
         "total_capacity": 26300318136401,
         "used_capacity": 19054536509358,
-        "free_capacity": 7245781627043
+        "free_capacity": 7245781627043,
+        'subscribed_capacity': 219902325555200
     }

--- a/delfin/tests/unit/api/v1/test_storage_pools.py
+++ b/delfin/tests/unit/api/v1/test_storage_pools.py
@@ -50,7 +50,8 @@ class TestStoragePoolController(test.TestCase):
                     "storage_type": "block",
                     "total_capacity": 26300318136401,
                     "used_capacity": 19054536509358,
-                    "free_capacity": 7245781627043
+                    "free_capacity": 7245781627043,
+                    'subscribed_capacity': 219902325555200
                 }
             ]
         }
@@ -79,7 +80,8 @@ class TestStoragePoolController(test.TestCase):
                     "storage_type": "block",
                     "total_capacity": 26300318136401,
                     "used_capacity": 19054536509358,
-                    "free_capacity": 7245781627043
+                    "free_capacity": 7245781627043,
+                    'subscribed_capacity': 219902325555200
                 }
             ]
         }
@@ -107,7 +109,8 @@ class TestStoragePoolController(test.TestCase):
             "storage_type": "block",
             "total_capacity": 26300318136401,
             "used_capacity": 19054536509358,
-            "free_capacity": 7245781627043
+            "free_capacity": 7245781627043,
+            'subscribed_capacity': 219902325555200
         }
         self.assertDictEqual(expctd_dict, res_dict)
 

--- a/delfin/tests/unit/api/v1/test_storages.py
+++ b/delfin/tests/unit/api/v1/test_storages.py
@@ -79,7 +79,9 @@ class TestStorageController(test.TestCase):
                     "description": "it is a fake driver.",
                     "serial_number": "2102453JPN12KA0000113",
                     "used_capacity": 3126,
-                    "total_capacity": 1048576
+                    "total_capacity": 1048576,
+                    'raw_capacity': 1610612736000,
+                    'subscribed_capacity': 219902325555200
                 },
                 {
                     "id": "277a1d8f-a36e-423e-bdd9-db154f32c289",
@@ -96,7 +98,9 @@ class TestStorageController(test.TestCase):
                     "description": "it is a fake driver.",
                     "serial_number": "2102453JPN12KA0000112",
                     "used_capacity": 3126,
-                    "total_capacity": 1048576
+                    "total_capacity": 1048576,
+                    'raw_capacity': 1610612736000,
+                    'subscribed_capacity': 219902325555200
                 }
             ]
         }
@@ -126,7 +130,9 @@ class TestStorageController(test.TestCase):
                     "description": "it is a fake driver.",
                     "serial_number": "2102453JPN12KA0000113",
                     "used_capacity": 3126,
-                    "total_capacity": 1048576
+                    "total_capacity": 1048576,
+                    'raw_capacity': 1610612736000,
+                    'subscribed_capacity': 219902325555200
                 }
             ]
         }
@@ -156,7 +162,9 @@ class TestStorageController(test.TestCase):
             "description": "it is a fake driver.",
             "serial_number": "2102453JPN12KA0000113",
             "used_capacity": 3126,
-            "total_capacity": 1048576
+            "total_capacity": 1048576,
+            'raw_capacity': 1610612736000,
+            'subscribed_capacity': 219902325555200
         }
         self.assertDictEqual(expctd_dict, res_dict)
 
@@ -186,6 +194,8 @@ class TestStorageController(test.TestCase):
                 'used_capacity': 3126,
                 'free_capacity': 1045449,
                 "sync_status": constants.SyncStatus.SYNCED,
+                'raw_capacity': 1610612736000,
+                'subscribed_capacity': 219902325555200
             }))
         self.mock_object(
             db, 'access_info_get_all',
@@ -225,6 +235,8 @@ class TestStorageController(test.TestCase):
             'used_capacity': 3126,
             'free_capacity': 1045449,
             "sync_status": "SYNCED",
+            'raw_capacity': 1610612736000,
+            'subscribed_capacity': 219902325555200
         }
         self.assertDictEqual(expctd_dict, res_dict)
 
@@ -245,6 +257,8 @@ class TestStorageController(test.TestCase):
                 'used_capacity': 3126,
                 'free_capacity': 1045449,
                 "sync_status": constants.SyncStatus.SYNCED,
+                'raw_capacity': 1610612736000,
+                'subscribed_capacity': 219902325555200
             }))
         self.mock_object(
             db, 'access_info_get_all',

--- a/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
+++ b/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
@@ -80,7 +80,9 @@ class TestVMAXStorageDriver(TestCase):
             'location': '',
             'total_capacity': 109951162777600,
             'used_capacity': 82463372083200,
-            'free_capacity': 27487790694400
+            'free_capacity': 27487790694400,
+            'raw_capacity': 1610612736000,
+            'subscribed_capacity': 219902325555200
         }
         kwargs = VMAX_STORAGE_CONF
 
@@ -95,7 +97,12 @@ class TestVMAXStorageDriver(TestCase):
                 ],
                 'system_capacity': {
                     'usable_total_tb': 100,
-                    'usable_used_tb': 75
+                    'usable_used_tb': 75,
+                    'subscribed_total_tb': 200
+                },
+                'physicalCapacity': {
+                    'total_capacity_gb': 1500
+
                 }
             }
             m.common.get_request.side_effect = \
@@ -128,7 +135,8 @@ class TestVMAXStorageDriver(TestCase):
             'storage_type': 'block',
             'total_capacity': 109951162777600,
             'used_capacity': 82463372083200,
-            'free_capacity': 27487790694400
+            'free_capacity': 27487790694400,
+            'subscribed_capacity': 219902325555200
         }]
         kwargs = VMAX_STORAGE_CONF
 
@@ -140,7 +148,8 @@ class TestVMAXStorageDriver(TestCase):
             pool_info = {
                 'srp_capacity': {
                     'usable_total_tb': 100,
-                    'usable_used_tb': 75
+                    'usable_used_tb': 75,
+                    'subscribed_total_tb': 200
                 },
                 'srpId': 'SRP_ID'
             }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adding raw_capacity and subscribed capacity for storage  and subscribed_capacity for pool in   VMAX driver 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #NA

**Test Report**:
POST v1/storages reposnse 
{
    "created_at": "2020-08-03T13:49:56.683352",
    "updated_at": null,
    "deleted_at": null,
    "deleted": 0,
    "id": "f6a9740c-4855-4339-9a24-7decd45490b0",
    "name": "",
    "vendor": "Dell EMC",
    "description": "",
    "model": "VMAX250F",
    "status": "normal",
    "serial_number": "12345678",
    "firmware_version": null,
    "location": "",
    "total_capacity": 26300318136401,
    "used_capacity": 20121062788300,
    "free_capacity": 6179255348101,
    "raw_capacity": 32479734545776,
    "subscribed_capacity": 166037250910453,
    "sync_status": "SYNCED"
}



GET v1/storages
{
    "storages": [
        {
            "created_at": "2020-08-03T13:49:56.683352",
            "updated_at": "2020-08-03T13:49:58.754501",
            "deleted_at": null,
            "deleted": 0,
            "id": "f6a9740c-4855-4339-9a24-7decd45490b0",
            "name": "",
            "vendor": "Dell EMC",
            "description": "",
            "model": "VMAX250F",
            "status": "normal",
            "serial_number": "123456789",
            "firmware_version": null,
            "location": "",
            "total_capacity": 26300318136401,
            "used_capacity": 20121062788300,
            "free_capacity": 6179255348101,
            "raw_capacity": 32479734545776,
            "subscribed_capacity": 166037250910453,
            "sync_status": "SYNCED"
        }
    ]
}

GET v1/storage-pools

{
    "storage_pools": [
        {
            "created_at": "2020-08-04T06:43:57.527892",
            "updated_at": null,
            "id": "5cf61b9e-65a7-47e3-83c3-8a280b694536",
            "name": "SRP_1",
            "storage_id": "7e12d530-5636-435b-b93c-2c06839ffdeb",
            "native_storage_pool_id": "SRP_1",
            "description": "Dell EMC VMAX Pool",
            "status": "normal",
            "storage_type": "block",
            "total_capacity": 26300318136401,
            "used_capacity": 20154048137134,
            "free_capacity": 6146269999267,
            "subscribed_capacity": 166037250910453
        }
    ]
}
**Special notes for your reviewer**:
NA
**Release note**:
<!--  Steps to write your release note:
1. raw_capacity andsubscribed_capacity support for VMAX

-->
```release-note
```
