### PR TITLE
Adding support for VMAX registration without array_id in access_info

### DIFF
--- a/delfin/drivers/dell_emc/vmax/vmax.py
+++ b/delfin/drivers/dell_emc/vmax/vmax.py
@@ -36,7 +36,9 @@ class VMAXStorageDriver(driver.StorageDriver):
 
     def get_storage(self, context):
         # Get the VMAX model
-        model = self.client.get_model()
+        array = self.client.get_array()
+        model = array['model']
+        ucode = array['ucode']
 
         # Get Storage details for capacity info
         storg_info = self.client.get_storage_capacity()
@@ -49,10 +51,13 @@ class VMAXStorageDriver(driver.StorageDriver):
         free_cap = total_cap - used_cap
 
         storage = {
-            'name': '',
+            # VMAX Rest API do not provide Array name .
+            # Generate  name  by combining model and symmetrixId
+            'name': model + '-' + self.client.array_id,
             'vendor': 'Dell EMC',
             'description': '',
             'model': model,
+            'firmware_version': ucode,
             'status': constants.StorageStatus.NORMAL,
             'serial_number': self.client.array_id,
             'location': '',


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
To support 
1. VMAX resgistration withour providing array_id for an embedded unisphere 
detailed requirement and impact analysis is here 
[VMAX registration support for embedded unipshere without providing array_id.docx](https://github.com/sodafoundation/delfin/files/5041406/VMAX.registration.support.for.embedded.unipshere.without.providing.array_id.docx)
2. Add firmware version and array name field from  VMAX driver for storage object

**Which issue this PR fixes** NA

**Special notes for your reviewer**:
PyU4V dependency is there in this PR. we have to remove the dependent code once the driver client re-write code is in.

**Test Report**:
Registration with array_id
<img width="233" alt="Capture" src="https://user-images.githubusercontent.com/45681499/89647002-707e0a80-d8da-11ea-814e-f64ec0d65cdd.PNG">

<img width="203" alt="Capture1" src="https://user-images.githubusercontent.com/45681499/89647014-75db5500-d8da-11ea-9a44-ee85ff623893.PNG">

Registration without array_id
<img width="241" alt="Capture3" src="https://user-images.githubusercontent.com/45681499/89647041-8095ea00-d8da-11ea-9809-112aa907b6cb.PNG">

<img width="282" alt="Capture4" src="https://user-images.githubusercontent.com/45681499/89647046-84297100-d8da-11ea-916c-fd4dfb0fec1f.PNG">

**Release note**:
1. VMAX Embedded unisphere support 
2. firmware_versionand name for storage from VMAX driver
```release-note
```
