### PR TITLE
Custom mib path enhancement

### DIFF
--- a/delfin/alert_manager/trap_receiver.py
+++ b/delfin/alert_manager/trap_receiver.py
@@ -20,7 +20,7 @@ from pysnmp.carrier.asyncore.dgram import udp
 from pysnmp.entity import engine, config
 from pysnmp.entity.rfc3413 import ntfrcv
 from pysnmp.proto.api import v2c
-from pysnmp.smi import builder, view, rfc1902, compiler
+from pysnmp.smi import builder, view, rfc1902
 
 from delfin import context, cryptor
 from delfin import db
@@ -33,7 +33,7 @@ from delfin.i18n import _
 
 LOG = log.getLogger(__name__)
 
-# Mib file list, can be .mib or .py(precompiled) format
+# Mib file list, in .py(precompiled) format
 MIB_LOAD_LIST = ['EMCGATEWAY-MIB', 'FCMGMT-MIB', 'ISM-HUAWEI-MIB']
 
 AUTH_PROTOCOL_MAP = {"sha": config.usmHMACSHAAuthProtocol,
@@ -160,12 +160,6 @@ class TrapReceiver(manager.Manager):
                 self.snmp_mib_path),)
             mib_builder.setMibSources(*mib_sources)
             if len(MIB_LOAD_LIST) > 0:
-                # Compile custom mib files (.mib) which will be used by pysnmp
-                # http://mibs.snmplabs.com/asn1/ for satisfying dependencies
-                compiler.addMibCompiler(mib_builder,
-                                        sources=[self.snmp_mib_path,
-                                                 'http://mibs.snmplabs.com'
-                                                 '/asn1/'])
                 mib_builder.loadModules(*MIB_LOAD_LIST)
         except Exception:
             raise ValueError("Mib load failed.")

--- a/delfin/alert_manager/trap_receiver.py
+++ b/delfin/alert_manager/trap_receiver.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import re
 import six
 
@@ -33,8 +34,8 @@ from delfin.i18n import _
 
 LOG = log.getLogger(__name__)
 
-# Mib file list, in .py(precompiled) format
-MIB_LOAD_LIST = ['EMCGATEWAY-MIB', 'FCMGMT-MIB', 'ISM-HUAWEI-MIB']
+# Mib file format to be loaded
+MIB_LOAD_FILE_FORMAT = '.py'
 
 AUTH_PROTOCOL_MAP = {"sha": config.usmHMACSHAAuthProtocol,
                      "md5": config.usmHMACMD5AuthProtocol}
@@ -159,8 +160,13 @@ class TrapReceiver(manager.Manager):
             mib_sources = mib_builder.getMibSources() + (builder.DirMibSource(
                 self.snmp_mib_path),)
             mib_builder.setMibSources(*mib_sources)
-            if len(MIB_LOAD_LIST) > 0:
-                mib_builder.loadModules(*MIB_LOAD_LIST)
+            files = []
+            for file in os.listdir(self.snmp_mib_path):
+                # Pick up all .py files, remove extenstion and load them
+                if file.endswith(MIB_LOAD_FILE_FORMAT):
+                    files.append(os.path.splitext(file)[0])
+            if len(files) > 0:
+                mib_builder.loadModules(*files)
         except Exception:
             raise ValueError("Mib load failed.")
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR addresses the issue related to mib load from custom path (delfin path here) in delfin alert manager 
It addresses 2 issues

1) In current implementation, custom path is overwriting the default mib path, so when it loads mibs with their dependencies mib load is failing as some mibs can not be found. Now it is modified so that custom path is appended to default pysnmp mib paths so that mib load will be success

2) Current implementation expects precompiled mib files for loading and processing. So mibs need to be precompiled using tools like mibdump to generate compiled files(.py) from .mib files

pysnmp itself provides library functions to automatically compile and then load programatically. 
Now the implemntation is modified so that .mib files can be given as it is as input in custom path
so .mib and precompiled files(.py format) both  will work fine

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
-NA-

**Special notes for your reviewer**:
Test report:

Custom mib path contents:
![image](https://user-images.githubusercontent.com/30930862/89714069-bc53b100-d9b9-11ea-9f56-5d03794c4cef.png)

Appeneded mib path:
![image](https://user-images.githubusercontent.com/30930862/89714127-33894500-d9ba-11ea-8300-1163c1ff6ff8.png)


Alert processing:
![image](https://user-images.githubusercontent.com/30930862/89714148-4f8ce680-d9ba-11ea-81e2-0c95ff63645d.png)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
