### PR TITLE
Update event type for alert model

### DIFF
--- a/delfin/alert_manager/alert_processor.py
+++ b/delfin/alert_manager/alert_processor.py
@@ -28,10 +28,11 @@ class AlertProcessor(object):
 
     def __init__(self):
         self.driver_manager = driver_manager.API()
+        self.exporter_manager = base_exporter.AlertExporterManager()
 
     def process_alert_info(self, alert):
         """Fills alert model using driver manager interface."""
-        ctxt = context.RequestContext()
+        ctxt = context.get_admin_context()
         storage = db.storage_get(ctxt, alert['storage_id'])
 
         try:
@@ -49,10 +50,5 @@ class AlertProcessor(object):
             raise exception.InvalidResults(
                 "Failed to fill the alert model from driver.")
 
-        self._export_alert_model(alert_model)
-
-    def _export_alert_model(self, alert_model):
-        """Exports the filled alert model to the export manager."""
-
         # Export to base exporter which handles dispatch for all exporters
-        base_exporter.dispatch_alert_model(alert_model)
+        self.exporter_manager.dispatch(ctxt, alert_model)

--- a/delfin/common/constants.py
+++ b/delfin/common/constants.py
@@ -13,7 +13,6 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-import enum
 
 # The maximum value a signed INT type may have
 DB_MAX_INT = 0x7FFFFFFF
@@ -65,7 +64,7 @@ class VolumeType(object):
 
 
 # Enumerations for alert severity
-class Severity(enum.Enum):
+class Severity(object):
     FATAL = 'Fatal'
     CRITICAL = 'Critical'
     MAJOR = 'Major'
@@ -76,10 +75,31 @@ class Severity(enum.Enum):
 
 
 # Enumerations for alert category
-class Category(enum.Enum):
+class Category(object):
     FAULT = 'Fault'
     EVENT = 'Event'
     RECOVERY = 'Recovery'
+    NOT_SPECIFIED = 'NotSpecified'
+
+
+# Enumerations for clear type
+class ClearType(object):
+    AUTOMATIC = 'Automatic'
+    MANUAL = 'Manual'
+
+
+# Enumerations for alert type based on X.733 Specification
+class EventType(object):
+    COMMUNICATIONS_ALARM = 'CommunicationsAlarm'
+    EQUIPMENT_ALARM = 'EquipmentAlarm'
+    PROCESSING_ERROR_ALARM = 'ProcessingErrorAlarm'
+    QUALITY_OF_SERVICE_ALARM = 'QualityOfServiceAlarm'
+    ENVIRONMENTAL_ALARM = 'EnvironmentalAlarm'
+    INTEGRITY_VIOLATION = 'IntegrityViolation'
+    OPERATIONAL_VIOLATION = 'OperationalViolation'
+    PHYSICAL_VIOLATION = 'PhysicalViolation'
+    SECURITY_MECHANISM_VIOLATION = 'SecurityServiceOrMechanismViolation'
+    TIME_DOMAIN_VIOLATION = 'TimeDomainViolation'
     NOT_SPECIFIED = 'NotSpecified'
 
 

--- a/delfin/drivers/dell_emc/vmax/alert_handler.py
+++ b/delfin/drivers/dell_emc/vmax/alert_handler.py
@@ -71,7 +71,7 @@ class AlertHandler(object):
             constants.Severity.INFORMATIONAL)
 
         alert_model['category'] = constants.Category.NOT_SPECIFIED
-        alert_model['type'] = alert['connUnitEventType']
+        alert_model['type'] = constants.EventType.EQUIPMENT_ALARM
 
         alert_model['sequence_number'] = alert['connUnitEventId']
 

--- a/delfin/exporter/base_exporter.py
+++ b/delfin/exporter/base_exporter.py
@@ -15,6 +15,7 @@
 
 from oslo_config import cfg
 from oslo_log import log
+import six
 from stevedore import extension
 
 from delfin import exception
@@ -53,14 +54,16 @@ class BaseManager(BaseExporter):
         self.exporters = self._get_exporters()
 
     def dispatch(self, ctxt, data):
+        if not isinstance(data, (list, tuple)):
+            data = [data]
         for exporter in self.exporters:
             try:
                 exporter.dispatch(ctxt, data)
             except exception.DelfinException as e:
                 err_msg = _("Failed to export data (%s).") % e.msg
                 LOG.exception(err_msg)
-            except Exception:
-                err_msg = _("Failed to export data.")
+            except Exception as e:
+                err_msg = six.text_type(e)
                 LOG.exception(err_msg)
 
     def _get_exporters(self):

--- a/delfin/tests/unit/alert_manager/fakes.py
+++ b/delfin/tests/unit/alert_manager/fakes.py
@@ -33,7 +33,7 @@ def fake_alert_model():
             'alert_name': 'SAMPLE_ALERT_NAME',
             'severity': constants.Severity.WARNING,
             'category': constants.Category.NOT_SPECIFIED,
-            'type': 'topology',
+            'type': constants.EventType.EQUIPMENT_ALARM,
             'sequence_number': 79,
             'description': 'Diagnostic event trace triggered.',
             'recovery_advice': 'NA',

--- a/delfin/tests/unit/drivers/dell_emc/vmax/test_alert_handler.py
+++ b/delfin/tests/unit/drivers/dell_emc/vmax/test_alert_handler.py
@@ -57,7 +57,7 @@ class AlertHandlerTestCase(unittest.TestCase):
                                 'severity': constants.Severity.WARNING,
                                 'category':
                                     constants.Category.NOT_SPECIFIED,
-                                'type': alert['connUnitEventType'],
+                                'type': constants.EventType.EQUIPMENT_ALARM,
                                 'sequence_number': alert['connUnitEventId'],
                                 'description': alert['connUnitEventDescr'],
                                 'recovery_advice': 'None',

--- a/delfin/tests/unit/drivers/huawei/oceanstor/test_alert_handler.py
+++ b/delfin/tests/unit/drivers/huawei/oceanstor/test_alert_handler.py
@@ -75,7 +75,7 @@ class AlertHandlerTestCase(unittest.TestCase):
                 'hwIsmReportingAlarmFaultTitle'],
             'severity': constants.Severity.CRITICAL,
             'category': constants.Category.FAULT,
-            'type': alert['hwIsmReportingAlarmFaultType'],
+            'type': constants.EventType.EQUIPMENT_ALARM,
             'sequence_number': alert['hwIsmReportingAlarmSerialNo'],
             'description': alert[
                 'hwIsmReportingAlarmAdditionInfo'],


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR will add event type for alert model based on [X.733](https://www.itu.int/rec/T-REC-X.733/en) specification, it includes:

```
# Enumerations for alert type based on X.733 Specification
class EventType(object):
    COMMUNICATIONS_ALARM = 'CommunicationsAlarm'
    EQUIPMENT_ALARM = 'EquipmentAlarm'
    PROCESSING_ERROR_ALARM = 'ProcessingErrorAlarm'
    QUALITY_OF_SERVICE_ALARM = 'QualityOfServiceAlarm'
    ENVIRONMENTAL_ALARM = 'EnvironmentalAlarm'
    INTEGRITY_VIOLATION = 'IntegrityViolation'
    OPERATIONAL_VIOLATION = 'OperationalViolation'
    PHYSICAL_VIOLATION = 'PhysicalViolation'
    SECURITY_MECHANISM_VIOLATION = 'SecurityServiceOrMechanismViolation'
    TIME_DOMAIN_VIOLATION = 'TimeDomainViolation'
    NOT_SPECIFIED = 'NotSpecified'
```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
