### PR TITLE
Fix oceanstor driver issue

### DIFF
--- a/delfin/drivers/huawei/oceanstor/alert_handler.py
+++ b/delfin/drivers/huawei/oceanstor/alert_handler.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import binascii
 from datetime import datetime
 
 from oslo_log import log
@@ -98,12 +97,14 @@ class AlertHandler(object):
 
             description = alert['hwIsmReportingAlarmAdditionInfo']
             if self._is_hex(description):
-                description = binascii.unhexlify(description[2:])
+                description = bytes.fromhex(description[2:]).decode('ascii')
             alert_model['description'] = description
 
             recovery_advice = alert['hwIsmReportingAlarmRestoreAdvice']
             if self._is_hex(recovery_advice):
-                recovery_advice = binascii.unhexlify(recovery_advice[2:])
+                recovery_advice = bytes.fromhex(
+                    recovery_advice[2:]).decode('ascii')
+
             alert_model['recovery_advice'] = recovery_advice
 
             alert_model['resource_type'] = constants.DEFAULT_RESOURCE_TYPE


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix the issue of jsom.dumps for oceanstor alert info which reported: ```TypeError: Object of type bytes is not JSON serializable. ```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
