### PR TITLE
 Adding name and firmware version for VMAX

### DIFF
--- a/delfin/drivers/dell_emc/vmax/client.py
+++ b/delfin/drivers/dell_emc/vmax/client.py
@@ -69,23 +69,13 @@ class VMAXClient(object):
                 format(array['symmetrixId'])
             raise exception.InvalidInput(msg)
 
-    def get_model(self):
+    def get_array_details(self):
         try:
-            # Get the VMAX model
-            return self.rest.get_vmax_model(version=self.uni_version,
-                                            array=self.array_id)
+            # Get the VMAX array properties
+            return self.rest.get_vmax_array_details(version=self.uni_version,
+                                                    array=self.array_id)
         except Exception as err:
-            msg = "Failed to get model from VMAX: {}".format(err)
-            LOG.error(msg)
-            raise exception.StorageBackendException(msg)
-
-    def get_ucode(self):
-        try:
-            # Get the VMAX ucode
-            return self.rest.get_vmax_ucode(version=self.uni_version,
-                                            array=self.array_id)
-        except Exception as err:
-            msg = "Failed to get ucode from VMAX: {}".format(err)
+            msg = "Failed to get array details from VMAX: {}".format(err)
             LOG.error(msg)
             raise exception.StorageBackendException(msg)
 

--- a/delfin/drivers/dell_emc/vmax/client.py
+++ b/delfin/drivers/dell_emc/vmax/client.py
@@ -79,6 +79,16 @@ class VMAXClient(object):
             LOG.error(msg)
             raise exception.StorageBackendException(msg)
 
+    def get_ucode(self):
+        try:
+            # Get the VMAX ucode
+            return self.rest.get_vmax_ucode(version=self.uni_version,
+                                            array=self.array_id)
+        except Exception as err:
+            msg = "Failed to get ucode from VMAX: {}".format(err)
+            LOG.error(msg)
+            raise exception.StorageBackendException(msg)
+
     def get_storage_capacity(self):
         try:
             storage_info = self.rest.get_system_capacity(

--- a/delfin/drivers/dell_emc/vmax/rest.py
+++ b/delfin/drivers/dell_emc/vmax/rest.py
@@ -407,6 +407,18 @@ class VMaxRest(object):
             vmax_version = system_info.get('model')
         return vmax_version
 
+    def get_vmax_ucode(self, version=U4V_VERSION, array=''):
+        """Get the VMax ucode.
+        :param version: the unisphere version
+        :param array: the array serial number
+        :returns: the VMax ucode
+        """
+        vmax_ucode = None
+        system_info = self.get_array_detail(version, array)
+        if system_info and system_info.get('ucode'):
+            vmax_ucode = system_info.get('ucode')
+        return vmax_ucode
+
     def get_array_model_info(self, version=U4V_VERSION, array=''):
         """Get the VMax model.
         :param version: the unisphere version

--- a/delfin/drivers/dell_emc/vmax/rest.py
+++ b/delfin/drivers/dell_emc/vmax/rest.py
@@ -410,10 +410,10 @@ class VMaxRest(object):
         if system_info and system_info.get('ucode'):
             vmax_ucode = system_info.get('ucode')
         if system_info and system_info.get('display_name'):
-            vmax_ucode = system_info.get('display_name')
+            vmax_display_name = system_info.get('display_name')
         array_details = {"model": vmax_version,
                          "ucode": vmax_ucode,
-                         "display_name": vmax_ucode}
+                         "display_name": vmax_display_name}
         return array_details
 
     def get_array_model_info(self, version=U4V_VERSION, array=''):

--- a/delfin/drivers/dell_emc/vmax/rest.py
+++ b/delfin/drivers/dell_emc/vmax/rest.py
@@ -395,29 +395,22 @@ class VMaxRest(object):
                                         params=None)
         return srp_details
 
-    def get_vmax_model(self, version=U4V_VERSION, array=''):
-        """Get the VMax model.
+    def get_vmax_array_details(self, version=U4V_VERSION, array=''):
+        """Get the VMax array properties.
         :param version: the unisphere version
         :param array: the array serial number
         :returns: the VMax model
         """
         vmax_version = None
+        vmax_ucode = None
         system_info = self.get_array_detail(version, array)
         if system_info and system_info.get('model'):
             vmax_version = system_info.get('model')
-        return vmax_version
-
-    def get_vmax_ucode(self, version=U4V_VERSION, array=''):
-        """Get the VMax ucode.
-        :param version: the unisphere version
-        :param array: the array serial number
-        :returns: the VMax ucode
-        """
-        vmax_ucode = None
-        system_info = self.get_array_detail(version, array)
         if system_info and system_info.get('ucode'):
             vmax_ucode = system_info.get('ucode')
-        return vmax_ucode
+        array_details = {"model": vmax_version,
+                         "ucode": vmax_ucode}
+        return array_details
 
     def get_array_model_info(self, version=U4V_VERSION, array=''):
         """Get the VMax model.

--- a/delfin/drivers/dell_emc/vmax/rest.py
+++ b/delfin/drivers/dell_emc/vmax/rest.py
@@ -403,13 +403,17 @@ class VMaxRest(object):
         """
         vmax_version = None
         vmax_ucode = None
+        vmax_display_name = None
         system_info = self.get_array_detail(version, array)
         if system_info and system_info.get('model'):
             vmax_version = system_info.get('model')
         if system_info and system_info.get('ucode'):
             vmax_ucode = system_info.get('ucode')
+        if system_info and system_info.get('display_name'):
+            vmax_ucode = system_info.get('display_name')
         array_details = {"model": vmax_version,
-                         "ucode": vmax_ucode}
+                         "ucode": vmax_ucode,
+                         "display_name": vmax_ucode}
         return array_details
 
     def get_array_model_info(self, version=U4V_VERSION, array=''):

--- a/delfin/drivers/dell_emc/vmax/vmax.py
+++ b/delfin/drivers/dell_emc/vmax/vmax.py
@@ -34,6 +34,7 @@ class VMAXStorageDriver(driver.StorageDriver):
     def get_storage(self, context):
         # Get the VMAX model
         model = self.client.get_model()
+        ucode = self.client.get_ucode()
 
         # Get Storage details for capacity info
         storg_info = self.client.get_storage_capacity()
@@ -46,10 +47,13 @@ class VMAXStorageDriver(driver.StorageDriver):
         free_cap = total_cap - used_cap
 
         storage = {
-            'name': '',
+            # Unisphere Rest API do not provide Array name .
+            # Generate  name  by combining model and symmetrixId
+            'name': model + '-' + self.client.array_id,
             'vendor': 'Dell EMC',
             'description': '',
             'model': model,
+            'firmware_version': ucode,
             'status': constants.StorageStatus.NORMAL,
             'serial_number': self.client.array_id,
             'location': '',

--- a/delfin/drivers/dell_emc/vmax/vmax.py
+++ b/delfin/drivers/dell_emc/vmax/vmax.py
@@ -33,8 +33,9 @@ class VMAXStorageDriver(driver.StorageDriver):
 
     def get_storage(self, context):
         # Get the VMAX model
-        model = self.client.get_model()
-        ucode = self.client.get_ucode()
+        array_details = self.client.get_array_details()
+        model = array_details['model']
+        ucode = array_details['ucode']
 
         # Get Storage details for capacity info
         storg_info = self.client.get_storage_capacity()

--- a/delfin/drivers/dell_emc/vmax/vmax.py
+++ b/delfin/drivers/dell_emc/vmax/vmax.py
@@ -36,6 +36,7 @@ class VMAXStorageDriver(driver.StorageDriver):
         array_details = self.client.get_array_details()
         model = array_details['model']
         ucode = array_details['ucode']
+        display_name = array_details['display_name']
 
         # Get Storage details for capacity info
         storg_info = self.client.get_storage_capacity()
@@ -50,7 +51,7 @@ class VMAXStorageDriver(driver.StorageDriver):
         storage = {
             # Unisphere Rest API do not provide Array name .
             # Generate  name  by combining model and symmetrixId
-            'name': model + '-' + self.client.array_id,
+            'name': display_name,
             'vendor': 'Dell EMC',
             'description': '',
             'model': model,

--- a/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
+++ b/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
@@ -117,8 +117,10 @@ class TestVMAXStorageDriver(TestCase):
         mock_rest.return_value = None
         mock_version.return_value = ['V9.0.2.7', '90']
         mock_array.return_value = {'symmetrixId': ['00112233']}
-        mock_array_details.return_value = {'model': 'VMAX250F',
-                                           'ucode': '5978.221.221'}
+        mock_array_details.return_value = {
+            'model': 'VMAX250F',
+            'ucode': '5978.221.221',
+            'display_name': 'VMAX250F-00112233'}
         mock_capacity.return_value = system_capacity
 
         driver = VMAXStorageDriver(**kwargs)
@@ -136,8 +138,10 @@ class TestVMAXStorageDriver(TestCase):
         self.assertIn('Failed to get array details from VMAX',
                       str(exc.exception))
 
-        mock_array_details.side_effect = [{'model': 'VMAX250F',
-                                           'ucode': '5978.221.221'}]
+        mock_array_details.side_effect = [{
+            'model': 'VMAX250F',
+            'ucode': '5978.221.221',
+            'display_name': 'VMAX250F-00112233'}]
 
         mock_capacity.side_effect = exception.StorageBackendException
         with self.assertRaises(Exception) as exc:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Name and frimware version field for storage object was missing for VMAX . 
This PR is to fetch ucode as firmware_version and update name as display_name

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # NA

**Special notes for your reviewer**:
This is modified PR for https://github.com/sodafoundation/delfin/pull/269 after rebasing to rewritten VMAX client.

**Test report**:
<img width="282" alt="Capture4" src="https://user-images.githubusercontent.com/45681499/90023115-f631f980-dcd0-11ea-8ea9-570dfbe6fad5.PNG">


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
