### PR TITLE
 Fetching Default SRP for volumes which are not associated with storage group

### DIFF
--- a/delfin/drivers/dell_emc/vmax/client.py
+++ b/delfin/drivers/dell_emc/vmax/client.py
@@ -141,6 +141,9 @@ class VMAXClient(object):
     def list_volumes(self, storage_id):
 
         try:
+            # Get default SRPs assigned for the array
+            default_srps = self.rest.get_default_srps(
+                self.array_id, version=self.uni_version)
             # List all volumes except data volumes
             volumes = self.rest.get_volume_list(
                 self.array_id, version=self.uni_version,
@@ -161,6 +164,7 @@ class VMAXClient(object):
                 vol = self.rest.get_volume(self.array_id,
                                            self.uni_version, volume)
 
+                emulation_type = vol['emulation']
                 total_cap = vol['cap_mb'] * units.Mi
                 used_cap = (total_cap * vol['allocated_percent']) / 100.0
                 free_cap = total_cap - used_cap
@@ -191,8 +195,8 @@ class VMAXClient(object):
                         self.array_id, self.uni_version, sg)
                     v['native_storage_pool_id'] = sg_info['srp']
                     v['compressed'] = sg_info['compression']
-
-                # TODO: Workaround when SG is, not available/not unique
+                else:
+                    v['native_storage_pool_id'] = default_srps[emulation_type]
 
                 volume_list.append(v)
 

--- a/delfin/drivers/dell_emc/vmax/rest.py
+++ b/delfin/drivers/dell_emc/vmax/rest.py
@@ -457,7 +457,7 @@ class VMaxRest(object):
         """Get the VMax array default SRPs.
         :param version: the unisphere version
         :param array: the array serial number
-        :returns: dictionary default_srps
+        :returns: dictionary default SRPs
         """
         default_fba_srp = None
         default_ckd_srp = None

--- a/delfin/drivers/dell_emc/vmax/rest.py
+++ b/delfin/drivers/dell_emc/vmax/rest.py
@@ -459,13 +459,9 @@ class VMaxRest(object):
         :param array: the array serial number
         :returns: dictionary default SRPs
         """
-        default_fba_srp = None
-        default_ckd_srp = None
         symmetrix_info = self.get_system_capacity(array, version)
-        if symmetrix_info and symmetrix_info.get('default_fba_srp'):
-            default_fba_srp = symmetrix_info.get('default_fba_srp')
-        if symmetrix_info and symmetrix_info.get('default_ckd_srp'):
-            default_ckd_srp = symmetrix_info.get('default_ckd_srp')
+        default_fba_srp = symmetrix_info.get('default_fba_srp', None)
+        default_ckd_srp = symmetrix_info.get('default_ckd_srp', None)
         default_srps = {"FBA": default_fba_srp,
                         "CKD": default_ckd_srp}
         return default_srps

--- a/delfin/drivers/dell_emc/vmax/rest.py
+++ b/delfin/drivers/dell_emc/vmax/rest.py
@@ -453,6 +453,23 @@ class VMaxRest(object):
                       {'array': array})
         return capacity_details
 
+    def get_default_srps(self, array, version=U4V_VERSION):
+        """Get the VMax array default SRPs.
+        :param version: the unisphere version
+        :param array: the array serial number
+        :returns: dictionary default_srps
+        """
+        default_fba_srp = None
+        default_ckd_srp = None
+        symmetrix_info = self.get_system_capacity(array, version)
+        if symmetrix_info and symmetrix_info.get('default_fba_srp'):
+            default_fba_srp = symmetrix_info.get('default_fba_srp')
+        if symmetrix_info and symmetrix_info.get('default_ckd_srp'):
+            default_ckd_srp = symmetrix_info.get('default_ckd_srp')
+        default_srps = {"FBA": default_fba_srp,
+                        "CKD": default_ckd_srp}
+        return default_srps
+
     def get_volume(self, array, version, device_id):
         """Get a VMax volume from array.
         :param array: the array serial number


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Currently delfin VMAX driver picks SRPs for volumes , if it has association with a storage group.
There can be many volumes which are created but not associated with Storage groups, 
This change is to pick the default SRP for volumes if it is not associtaed with a storage group.
**Some points considered for this solution**
-By default VMAX storage array has a single SRP containing all the configured data pools.
- When multiple storage resource pools are configured, one of the storage resource pools must be marked as being the default storage resource pool

- All thin devices are associated with the default SRP upon creation
- every volume has a emulation type FBA or CKD
- There are two emulation types supported by VMAX [ 'FBA' and 'CKD'], and system provides details of the dfault  SRPs used for this emulation
![Screenshot from 2020-08-20 16-03-10](https://user-images.githubusercontent.com/45681499/90761301-d28a3700-e300-11ea-929a-ed1ed80f2a89.png)

- When a volume is associted with storage group, associated SRP becomes the SRP associted to that storage group.
- Storage groups can be associated with a single  storage resource pool, 
- SRPs  in VMAX are FAST VP managed , A volume  can only belong to one Storage Group that is associated with a FAST VP.
- if there is no SG associated with the volume , based on the emulation type of volume , we can get the default SRP for that volume.

More detailes about VMAX SRP and other groups.


https://www.dellemc.com/en-me/collaterals/unauth/white-papers/products/storage-1/h14040-understanding-storage-resource-pools-emc-vmax3-storage-arrays.pdf
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #74 

**Test Report**:
**VMAX REST reponse for GET symmetrix/<symmetric_id>**
<img width="303" alt="rest_query_for_default_srp (1)" src="https://user-images.githubusercontent.com/45681499/90761503-2006a400-e301-11ea-8324-f689f31ac670.PNG">

**GET volume without this change**
![volume_00053_without_defualt_pool](https://user-images.githubusercontent.com/45681499/90761553-33197400-e301-11ea-93ed-f5546122f060.PNG)

**GET volume with this change**
![volume_00053_with_defualt_pool](https://user-images.githubusercontent.com/45681499/90761595-40366300-e301-11ea-9dca-a1f226d9c7ae.PNG)


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
