### PR TITLE
Clear alert fix in hpe 3par driver

### DIFF
--- a/delfin/drivers/hpe/hpe_3par/alert_handler.py
+++ b/delfin/drivers/hpe/hpe_3par/alert_handler.py
@@ -133,8 +133,8 @@ class AlertHandler(object):
         re = 'Failed'
         try:
             if alert is not None:
-                re = self.sshhanlder.remove_alerts(context, alert.get(
-                    'sequence_number'))
+                # alert is sequence number here
+                re = self.sshhanlder.remove_alerts(context, alert)
                 if not re:
                     re = 'Success'
                 else:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For clear_alert function, alert_id/sequence number itself is input not dict which is fixed here


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
