### PR TITLE
Exception handling for delete snmp trap config

### DIFF
--- a/delfin/alert_manager/trap_receiver.py
+++ b/delfin/alert_manager/trap_receiver.py
@@ -106,8 +106,13 @@ class TrapReceiver(manager.Manager):
             engine_id = snmp_config.get('engine_id')
             if engine_id:
                 engine_id = v2c.OctetString(hexValue=engine_id)
-            config.delV3User(self.snmp_engine, userName=username,
-                             securityEngineId=engine_id)
+            try:
+                config.delV3User(self.snmp_engine, userName=username,
+                                 securityEngineId=engine_id)
+            except Exception as e:
+                msg = six.text_type(e)
+                LOG.warning("Snmp trap configuration to be "
+                            "deleted could not be found. Reason: %s", msg)
         else:
             storage_id = snmp_config.get('storage_id')
             community_index = self._get_community_index(storage_id)

--- a/delfin/tests/unit/alert_manager/fakes.py
+++ b/delfin/tests/unit/alert_manager/fakes.py
@@ -106,3 +106,7 @@ def load_config_exception(para):
 
 def mock_add_transport(snmpEngine, transportDomain, transport):
     snmpEngine.transportDispatcher = AsyncoreDispatcher()
+
+
+def config_delv3_exception(snmp_engine, username, securityEngineId):
+    raise exception.InvalidResults("Config delete failed.")

--- a/delfin/tests/unit/alert_manager/test_trap_receiver.py
+++ b/delfin/tests/unit/alert_manager/test_trap_receiver.py
@@ -203,6 +203,17 @@ class TrapReceiverTestCase(test.TestCase):
         # Verify that delV3User to del config from engine
         self.assertTrue(mock_del_config.called)
 
+    @mock.patch('pysnmp.entity.config.delV3User', fakes.config_delv3_exception)
+    @mock.patch('logging.LoggerAdapter.warning')
+    def test_sync_snmp_config_del_exception(self, mock_log_warning):
+        ctxt = {}
+        alert_config = fakes.fake_v3_alert_source()
+        trap_receiver_inst = self._get_trap_receiver()
+        trap_receiver_inst.snmp_engine = engine.SnmpEngine()
+        trap_receiver_inst.sync_snmp_config(ctxt,
+                                            snmp_config_to_del=alert_config)
+        self.assertTrue(mock_log_warning.called)
+
     def test_sync_snmp_config_invalid_auth_protocol(self):
         ctxt = {}
         alert_source_config = fakes.fake_v3_alert_source()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When alert source configuration is done for a given storage id, below events will happen

1) At API side, Configuration updated to db
2) Trap receiver notified about new config. So 
    a)current configuration deleted, 
    b)new configuration validated
    c)new configuration added at trap receiver side
3) During this process, between steps a) and b) , if configuration change is triggered again, delete trap configuration is triggered again before addition of previous configuration. 

When pysnmp received delete configuration  for user which is already deleted it results in exception
This is applicable only for v3 

So it is possible that user triggered config change again before previous config change is completed
So if delete v3 config fails, handle exception and log the warning and proceed

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Test report:**
![image](https://user-images.githubusercontent.com/30930862/92786907-47afd000-f3c6-11ea-9a7d-769f33553ba5.png)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
