### PR TITLE
Fix volume name in VMAX driver

### DIFF
--- a/delfin/drivers/dell_emc/vmax/client.py
+++ b/delfin/drivers/dell_emc/vmax/client.py
@@ -186,8 +186,12 @@ class VMAXClient(object):
                 if vol['type'] == 'TDEV':
                     description = "Dell EMC VMAX 'thin device' volume"
 
+                name = volume
+                if vol.get('volume_identifier'):
+                    name = volume + ':' + vol['volume_identifier']
+
                 v = {
-                    "name": volume,
+                    "name": name,
                     "storage_id": storage_id,
                     "description": description,
                     "status": status,

--- a/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
+++ b/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
@@ -228,6 +228,19 @@ class TestVMAXStorageDriver(TestCase):
             'free_capacity': 94371840,
             'native_storage_pool_id': 'SRP_1',
             'compressed': True
+        },
+            {
+            'name': 'volume_2:id',
+            'storage_id': '12345',
+            'description': "Dell EMC VMAX 'thin device' volume",
+            'type': 'thin',
+            'status': 'available',
+            'native_volume_id': '00002',
+            'wwn': 'wwn1234',
+            'total_capacity': 104857600,
+            'used_capacity': 10485760,
+            'free_capacity': 94371840,
+            'native_storage_pool_id': 'SRP_1'
         }]
         volumes = {
             'volumeId': '00001',
@@ -242,6 +255,7 @@ class TestVMAXStorageDriver(TestCase):
         }
         volumes1 = {
             'volumeId': '00002',
+            'volume_identifier': 'id',
             'cap_mb': 100,
             'allocated_percent': 10,
             'status': 'Ready',
@@ -284,6 +298,7 @@ class TestVMAXStorageDriver(TestCase):
         self.assertEqual(driver.client.array_id, "00112233")
         ret = driver.list_volumes(context)
         self.assertDictEqual(ret[0], expected[0])
+        self.assertDictEqual(ret[1], expected[1])
 
         mock_vols.side_effect = [['volume_1']]
         mock_vol.side_effect = [volumes]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix volume name in VMAX driver

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #332 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
