### PR TITLE
 VMAX driver Performance collection: Initial framework and  array level for metrics collection   

### DIFF
--- a/delfin/common/constants.py
+++ b/delfin/common/constants.py
@@ -150,7 +150,7 @@ class SecurityLevel(object):
 
 # Performance collection constants and common models
 # Metric model
-MetricStruct = namedtuple("Metric", "name labels values")
+metric_struct = namedtuple("Metric", "name labels values")
 
 
 # Unified Array metrics model

--- a/delfin/common/constants.py
+++ b/delfin/common/constants.py
@@ -13,6 +13,8 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from collections import namedtuple
+
 from pysnmp.entity import config
 
 # The maximum value a signed INT type may have
@@ -144,3 +146,20 @@ class SecurityLevel(object):
     AUTHPRIV = 'authPriv'
     AUTHNOPRIV = 'authNoPriv'
     NOAUTHNOPRIV = 'noAuthnoPriv'
+
+
+# Performance collection constants and common models
+# Metric model
+MetricStruct = namedtuple("Metric", "name labels values")
+
+
+# Unified Array metrics model
+DELFIN_ARRAY_METRICS = [
+    "response_time",
+    "throughput",
+    "read_throughput",
+    "write_throughput",
+    "bandwidth",
+    "read_bandwidth",
+    "write_bandwidth"
+]

--- a/delfin/drivers/dell_emc/vmax/client.py
+++ b/delfin/drivers/dell_emc/vmax/client.py
@@ -17,7 +17,7 @@ from oslo_utils import units
 
 from delfin import exception
 from delfin.common import constants
-from delfin.drivers.dell_emc.vmax import rest
+from delfin.drivers.dell_emc.vmax import rest, perf_utils
 
 LOG = log.getLogger(__name__)
 
@@ -226,3 +226,31 @@ class VMAXClient(object):
         """Clear alert for given sequence number."""
         return self.rest.clear_alert(sequence_number, version=self.uni_version,
                                      array=self.array_id)
+
+    def get_array_performance_metrics(self, storage_id, interval):
+        """Get performance metrics."""
+        try:
+            # Fetch VMAX Array Performance data from REST client
+            # TODO  :
+            #  Check whether array is registered for performance collection
+            #  in unisphere
+            perf_data = self.rest.get_array_performance_metrics(
+                self.array_id, interval)
+            # parse VMAX REST response to metric->values map
+            metrics_value_map = perf_utils.parse_performance_data(perf_data)
+            # prepare  labels required for array_leval performance data
+            labels = {'storage_id': storage_id, 'resource_type': 'array'}
+            # map to unified delifn  metrics
+            delfin_metrics = perf_utils.\
+                map_array_perf_metrics_to_delfin_metrics(metrics_value_map)
+            metrics_array = []
+            for key in constants.DELFIN_ARRAY_METRICS:
+                m = constants.MetricStruct(name=key, labels=labels,
+                                           values=delfin_metrics[key])
+                metrics_array.append(m)
+            return metrics_array
+        except Exception as err:
+            msg = "Failed to get performance metrics data for VMAX: {}".format(
+                err)
+            LOG.error(msg)
+            raise exception.StorageBackendException(msg)

--- a/delfin/drivers/dell_emc/vmax/client.py
+++ b/delfin/drivers/dell_emc/vmax/client.py
@@ -245,8 +245,8 @@ class VMAXClient(object):
                 map_array_perf_metrics_to_delfin_metrics(metrics_value_map)
             metrics_array = []
             for key in constants.DELFIN_ARRAY_METRICS:
-                m = constants.MetricStruct(name=key, labels=labels,
-                                           values=delfin_metrics[key])
+                m = constants.metric_struct(name=key, labels=labels,
+                                            values=delfin_metrics[key])
                 metrics_array.append(m)
             return metrics_array
         except Exception as err:

--- a/delfin/drivers/dell_emc/vmax/constants.py
+++ b/delfin/drivers/dell_emc/vmax/constants.py
@@ -1,0 +1,28 @@
+# Copyright 2020 The SODA Authors.
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+# minimum interval supported by VMAX
+VMAX_PERF_MIN_INTERVAL = 5
+
+ARRAY_METRICS = ["HostIOs",
+                 "HostMBWritten",
+                 "ReadResponseTime",
+                 "HostMBReads",
+                 "HostReads",
+                 "HostWrites",
+                 "WriteResponseTime"
+                 ]
+VMAX_REST_TARGET_URI_ARRAY_PERF = '/performance/Array/metrics'

--- a/delfin/drivers/dell_emc/vmax/perf_utils.py
+++ b/delfin/drivers/dell_emc/vmax/perf_utils.py
@@ -1,0 +1,108 @@
+# Copyright 2020 The SODA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+# minimum interval supported by VMAX
+VMAX_PERF_MIN_INTERVAL = 5
+
+ARRAY_METRICS = ["HostIOs",
+                 "HostMBWritten",
+                 "ReadResponseTime",
+                 "HostMBReads",
+                 "HostReads",
+                 "HostWrites",
+                 "WriteResponseTime"
+                 ]
+
+VMAX_REST_TARGET_URI_ARRAY_PERF = '/performance/Array/metrics'
+
+
+def epoch_time_ms_now():
+    """Get current time in epoch ms.
+    :returns: epoch time in milli seconds
+     """
+    ms = int(time.time() * 1000)
+    return ms
+
+
+def epoch_time_interval_ago(interval_seconds=VMAX_PERF_MIN_INTERVAL):
+    """Get epoch time in milliseconds  before an interval
+    :param interval_seconds: interval in seconds
+    :returns: epoch time in milliseconds
+    """
+    return int(epoch_time_ms_now() - (interval_seconds * 1000))
+
+
+def generate_performance_payload(array, interval, metrics):
+    """Generate request payload for VMAX performance POST request
+    :param array: symmetrixID
+    :param interval: interval in seconds
+    :returns: payload dictionary
+    """
+    return {'symmetrixId': str(array),
+            "endDate": epoch_time_ms_now(),
+            "startDate": epoch_time_interval_ago(interval),
+            "metrics": metrics,
+            "dataFormat": "Average"}
+
+
+def parse_performance_data(response):
+    """Parse metrics response to a map
+    :param response: response from unispshere REST API
+    :returns: map with key as metric name and value as dictionary
+        containing {timestamp: value} for a the timestamps available
+    """
+    metrics_map = {}
+    for metrics in response["resultList"]["result"]:
+        timestamp = metrics["timestamp"]
+        for key, value in metrics.items():
+            metrics_map[key] = metrics_map.get(key, {})
+            metrics_map[key][timestamp] = value
+    return metrics_map
+
+
+def map_array_perf_metrics_to_delfin_metrics(metrics_value_map):
+    """map vmax array performance metrics values  to delfin metrics values
+        :param metrics_value_map: metric to values map of vmax metrics
+        :returns: map with key as delfin metric name and value as dictionary
+            containing {timestamp: value} for a the timestamps available
+        """
+    # read and write response_time
+    read_response_values_dict = metrics_value_map['ReadResponseTime']
+    write_response_values_dict = metrics_value_map['WriteResponseTime']
+    # response_time_values is sum of read and write response
+    response_time_values_dict = {
+        x: read_response_values_dict.get(x, 0)
+        + write_response_values_dict.get(x, 0) for x in
+        set(read_response_values_dict).union(write_response_values_dict)}
+    # bandwidth metrics
+    read_bandwidth_values_dict = metrics_value_map['HostMBReads']
+    write_bandwidth_values_dict = metrics_value_map['HostMBWritten']
+    bandwidth_values_dict = {
+        x: read_bandwidth_values_dict.get(x, 0)
+        + write_bandwidth_values_dict.get(x, 0) for x in
+        set(read_bandwidth_values_dict).union(write_bandwidth_values_dict)}
+    throughput_values_dict = metrics_value_map['HostIOs']
+    read_throughput_values_dict = metrics_value_map['HostReads']
+    write_throughput_values_dict = metrics_value_map['HostWrites']
+    # map values to delfin metrics spec
+    delfin_metrics = {'response_time': response_time_values_dict,
+                      'read_bandwidth': read_bandwidth_values_dict,
+                      'write_bandwidth': write_bandwidth_values_dict,
+                      'throughput': throughput_values_dict,
+                      'read_throughput': read_throughput_values_dict,
+                      'write_throughput': write_throughput_values_dict,
+                      'bandwidth': bandwidth_values_dict}
+    return delfin_metrics

--- a/delfin/drivers/dell_emc/vmax/rest.py
+++ b/delfin/drivers/dell_emc/vmax/rest.py
@@ -26,6 +26,7 @@ from oslo_log import log as logging
 
 from delfin import exception
 from delfin.common import alert_util
+from delfin.drivers.dell_emc.vmax import perf_utils
 from delfin.i18n import _
 
 LOG = logging.getLogger(__name__)
@@ -518,6 +519,38 @@ class VMaxRest(object):
         except (KeyError, TypeError):
             pass
         return device_ids
+
+    def post_request(self, target_uri, payload):
+        """Generate  a POST request.
+        :param target_uri: the uri to query from unipshere REST API
+        :param payload: the payload
+        :returns: status_code -- int, message -- string, server response
+        """
+
+        status_code, message = self.request(target_uri, POST,
+                                            request_object=payload)
+        operation = 'Performance query for URL' % {target_uri}
+        self.check_status_code_success(
+            operation, status_code, message)
+        return status_code, message
+
+    def get_array_performance_metrics(self, array, interval):
+        """Get a array performance metrics from VMAX unipshere REST API.
+        :param array: the array serial number
+        :param interval: difference between start and end time
+
+        :returns: message -- response from unipshere REST API
+         """
+
+        target_uri = perf_utils.VMAX_REST_TARGET_URI_ARRAY_PERF
+        payload = perf_utils.generate_performance_payload(
+            array, interval, perf_utils.ARRAY_METRICS)
+
+        status_code, message = self.post_request(target_uri, payload)
+        # Expected 200 when POST request has metrics in response body
+        if status_code != STATUS_200:
+            raise exception.StoragePerformanceCollectionFailed(message)
+        return message
 
     def list_pagination(self, list_info):
         """Process lists under or over the maxPageSize

--- a/delfin/drivers/dell_emc/vmax/rest.py
+++ b/delfin/drivers/dell_emc/vmax/rest.py
@@ -26,7 +26,7 @@ from oslo_log import log as logging
 
 from delfin import exception
 from delfin.common import alert_util
-from delfin.drivers.dell_emc.vmax import perf_utils
+from delfin.drivers.dell_emc.vmax import perf_utils, constants
 from delfin.i18n import _
 
 LOG = logging.getLogger(__name__)
@@ -529,7 +529,7 @@ class VMaxRest(object):
 
         status_code, message = self.request(target_uri, POST,
                                             request_object=payload)
-        operation = 'Performance query for URL' % {target_uri}
+        operation = 'POST request for URL' % {target_uri}
         self.check_status_code_success(
             operation, status_code, message)
         return status_code, message
@@ -542,9 +542,9 @@ class VMaxRest(object):
         :returns: message -- response from unipshere REST API
          """
 
-        target_uri = perf_utils.VMAX_REST_TARGET_URI_ARRAY_PERF
+        target_uri = constants.VMAX_REST_TARGET_URI_ARRAY_PERF
         payload = perf_utils.generate_performance_payload(
-            array, interval, perf_utils.ARRAY_METRICS)
+            array, interval, constants.ARRAY_METRICS)
 
         status_code, message = self.post_request(target_uri, payload)
         # Expected 200 when POST request has metrics in response body

--- a/delfin/drivers/dell_emc/vmax/vmax.py
+++ b/delfin/drivers/dell_emc/vmax/vmax.py
@@ -17,7 +17,7 @@ from oslo_utils import units
 from delfin.common import constants
 from delfin.drivers.dell_emc.vmax.alert_handler import snmp_alerts
 from delfin.drivers.dell_emc.vmax.alert_handler import unisphere_alerts
-from delfin.drivers.dell_emc.vmax import client, perf_utils
+from delfin.drivers.dell_emc.vmax import client, constants as vmax_const
 from delfin.drivers import driver
 
 LOG = log.getLogger(__name__)
@@ -99,6 +99,6 @@ class VMAXStorageDriver(driver.StorageDriver):
     def collect_array_metrics(self, context, storage_id,
                               interval, is_historic):
         if not is_historic:
-            interval = perf_utils.VMAX_PERF_MIN_INTERVAL
+            interval = vmax_const.VMAX_PERF_MIN_INTERVAL
         return self.client.get_array_performance_metrics(self.storage_id,
                                                          interval=interval)

--- a/delfin/drivers/dell_emc/vmax/vmax.py
+++ b/delfin/drivers/dell_emc/vmax/vmax.py
@@ -17,7 +17,7 @@ from oslo_utils import units
 from delfin.common import constants
 from delfin.drivers.dell_emc.vmax.alert_handler import snmp_alerts
 from delfin.drivers.dell_emc.vmax.alert_handler import unisphere_alerts
-from delfin.drivers.dell_emc.vmax import client
+from delfin.drivers.dell_emc.vmax import client, perf_utils
 from delfin.drivers import driver
 
 LOG = log.getLogger(__name__)
@@ -95,3 +95,10 @@ class VMAXStorageDriver(driver.StorageDriver):
         alert_model_list = unisphere_alerts.AlertHandler()\
             .parse_queried_alerts(alert_list)
         return alert_model_list
+
+    def collect_array_metrics(self, context, storage_id,
+                              interval, is_historic):
+        if not is_historic:
+            interval = perf_utils.VMAX_PERF_MIN_INTERVAL
+        return self.client.get_array_performance_metrics(self.storage_id,
+                                                         interval=interval)

--- a/delfin/exception.py
+++ b/delfin/exception.py
@@ -260,3 +260,7 @@ class HTTPConnectionTimeout(DelfinException):
 
 class InvalidCAPath(DelfinException):
     msg_fmt = _("Invalid CA path: {0}.")
+
+
+class StoragePerformanceCollectionFailed(DelfinException):
+    msg_fmt = _("Failed to collect performance metrics. Reason: {0}.")

--- a/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
+++ b/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
@@ -16,6 +16,7 @@
 from unittest import TestCase, mock
 from delfin import exception
 from delfin import context
+from delfin.common import constants
 from delfin.drivers.dell_emc.vmax.vmax import VMAXStorageDriver
 from delfin.drivers.dell_emc.vmax.rest import VMaxRest
 
@@ -310,4 +311,259 @@ class TestVMAXStorageDriver(TestCase):
             driver.list_volumes(context)
 
         self.assertIn('Failed to get list volumes from VMAX',
+                      str(exc.exception))
+
+    @mock.patch.object(VMaxRest, 'post_request')
+    @mock.patch.object(VMaxRest, 'get_array_detail')
+    @mock.patch.object(VMaxRest, 'get_uni_version')
+    @mock.patch.object(VMaxRest, 'set_rest_credentials')
+    def test_get_storage_performance(self,
+                                     mock_rest, mock_version,
+                                     mock_array, mock_performnace):
+        vmax_array_perf_resp_historic = {
+            "expirationTime": 1600172441701,
+            "count": 4321,
+            "maxPageSize": 1000,
+            "id": "d495891f-1607-42b7-ba8d-44d0786bd335_0",
+            "resultList": {
+                "result": [
+                    {
+                        "HostIOs": 296.1,
+                        "HostMBWritten": 0.31862956,
+                        "ReadResponseTime": 4.4177675,
+                        "HostMBReads": 0.05016927,
+                        "HostReads": 14.056666,
+                        "HostWrites": 25.78,
+                        "WriteResponseTime": 4.7228317,
+                        "timestamp": 1598875800000
+                    },
+                    {
+                        "HostIOs": 350.22998,
+                        "HostMBWritten": 0.40306965,
+                        "ReadResponseTime": 4.396796,
+                        "HostMBReads": 0.043291014,
+                        "HostReads": 13.213333,
+                        "HostWrites": 45.97333,
+                        "WriteResponseTime": 4.7806735,
+                        "timestamp": 1598876100000
+                    },
+                    {
+                        "HostIOs": 297.63333,
+                        "HostMBWritten": 0.25046548,
+                        "ReadResponseTime": 4.3915706,
+                        "HostMBReads": 0.042753905,
+                        "HostReads": 13.176666,
+                        "HostWrites": 28.643333,
+                        "WriteResponseTime": 4.8760557,
+                        "timestamp": 1598876400000
+                    }
+                ]
+            }
+        }
+        vmax_array_perf_resp_real_time = {
+            "expirationTime": 1600172441701,
+            "count": 4321,
+            "maxPageSize": 1000,
+            "id": "d495891f-1607-42b7-ba8d-44d0786bd335_0",
+            "resultList": {
+                "result": [
+                    {
+                        "HostIOs": 296.1,
+                        "HostMBWritten": 0.31862956,
+                        "ReadResponseTime": 4.4177675,
+                        "HostMBReads": 0.05016927,
+                        "HostReads": 14.056666,
+                        "HostWrites": 25.78,
+                        "WriteResponseTime": 4.7228317,
+                        "timestamp": 1598875800000
+                    }
+                ]
+            }
+        }
+
+        expected_historic = [constants.MetricStruct(name='response_time',
+                                                    labels={
+                                                        'storage_id': '12345',
+                                                        'resource_type':
+                                                            'array'},
+                                                    values={
+                                                        1598875800000:
+                                                            9.1405992,
+                                                        1598876400000:
+                                                            9.2676263,
+                                                        1598876100000:
+                                                            9.1774695}
+                                                    ),
+                             constants.MetricStruct(name='throughput',
+                                                    labels={
+                                                        'storage_id': '12345',
+                                                        'resource_type':
+                                                            'array'},
+                                                    values={
+                                                        1598875800000: 296.1,
+                                                        1598876100000:
+                                                            350.22998,
+                                                        1598876400000:
+                                                            297.63333}
+                                                    ),
+                             constants.MetricStruct(name='read_throughput',
+                                                    labels={
+                                                        'storage_id': '12345',
+                                                        'resource_type':
+                                                            'array'},
+                                                    values={
+                                                        1598875800000:
+                                                            14.056666,
+                                                        1598876100000:
+                                                            13.213333,
+                                                        1598876400000:
+                                                            13.176666}
+                                                    ),
+                             constants.MetricStruct(name='write_throughput',
+                                                    labels={
+                                                        'storage_id': '12345',
+                                                        'resource_type':
+                                                            'array'},
+                                                    values={
+                                                        1598875800000: 25.78,
+                                                        1598876100000:
+                                                            45.97333,
+                                                        1598876400000:
+                                                            28.643333}
+                                                    ),
+                             constants.MetricStruct(name='bandwidth',
+                                                    labels={
+                                                        'storage_id': '12345',
+                                                        'resource_type':
+                                                            'array'},
+                                                    values={
+                                                        1598875800000:
+                                                        0.36879882999999997,
+                                                        1598876400000:
+                                                            0.293219385,
+                                                        1598876100000:
+                                                            0.446360664}
+                                                    ),
+                             constants.MetricStruct(name='read_bandwidth',
+                                                    labels={
+                                                        'storage_id': '12345',
+                                                        'resource_type':
+                                                            'array'},
+                                                    values={
+                                                        1598875800000:
+                                                            0.05016927,
+                                                        1598876100000:
+                                                            0.043291014,
+                                                        1598876400000:
+                                                            0.042753905}
+                                                    ),
+                             constants.MetricStruct(name='write_bandwidth',
+                                                    labels={
+                                                        'storage_id': '12345',
+                                                        'resource_type':
+                                                            'array'},
+                                                    values={
+                                                        1598875800000:
+                                                            0.31862956,
+                                                        1598876100000:
+                                                            0.40306965,
+                                                        1598876400000:
+                                                            0.25046548}
+                                                    )
+                             ]
+
+        expected_realtime = [
+            constants.MetricStruct(name='response_time',
+                                   labels={
+                                       'storage_id': '12345',
+                                       'resource_type':
+                                           'array'},
+                                   values={
+                                       1598875800000:
+                                           9.1405992
+                                   }
+                                   ),
+            constants.MetricStruct(name='throughput',
+                                   labels={
+                                       'storage_id': '12345',
+                                       'resource_type':
+                                           'array'},
+                                   values={
+                                       1598875800000: 296.1
+                                   }
+                                   ),
+            constants.MetricStruct(name='read_throughput',
+                                   labels={
+                                       'storage_id': '12345',
+                                       'resource_type':
+                                           'array'},
+                                   values={
+                                       1598875800000:
+                                           14.056666
+                                   }
+                                   ),
+            constants.MetricStruct(name='write_throughput',
+                                   labels={
+                                       'storage_id': '12345',
+                                       'resource_type':
+                                           'array'},
+                                   values={
+                                       1598875800000: 25.78
+                                   }
+                                   ),
+            constants.MetricStruct(name='bandwidth',
+                                   labels={
+                                       'storage_id': '12345',
+                                       'resource_type':
+                                           'array'},
+                                   values={
+                                       1598875800000:
+                                           0.36879882999999997
+                                   }
+                                   ),
+            constants.MetricStruct(name='read_bandwidth',
+                                   labels={
+                                       'storage_id': '12345',
+                                       'resource_type':
+                                           'array'},
+                                   values={
+                                       1598875800000:
+                                           0.05016927
+                                   }
+                                   ),
+            constants.MetricStruct(name='write_bandwidth',
+                                   labels={
+                                       'storage_id': '12345',
+                                       'resource_type': 'array'
+                                   },
+                                   values={
+                                       1598875800000: 0.31862956
+
+                                   }
+                                   )
+        ]
+
+        kwargs = VMAX_STORAGE_CONF
+        mock_rest.return_value = None
+        mock_version.return_value = ['V9.0.2.7', '90']
+        mock_array.return_value = {'symmetrixId': ['00112233']}
+        mock_performnace.return_value = 200, vmax_array_perf_resp_historic
+
+        driver = VMAXStorageDriver(**kwargs)
+        self.assertEqual(driver.storage_id, "12345")
+        self.assertEqual(driver.client.array_id, "00112233")
+
+        ret = driver.collect_array_metrics(context, '12345', 900, True)
+        self.assertEqual(ret, expected_historic)
+
+        mock_performnace.return_value = 200, vmax_array_perf_resp_real_time
+        ret = driver.collect_array_metrics(context, '12345', 0, False)
+        self.assertEqual(ret, expected_realtime)
+
+        mock_performnace.side_effect = \
+            exception.StoragePerformanceCollectionFailed
+        with self.assertRaises(Exception) as exc:
+            ret = driver.collect_array_metrics(context, '12345', 900, True)
+
+        self.assertIn('Failed to collect performance metrics. Reason',
                       str(exc.exception))

--- a/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
+++ b/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
@@ -381,166 +381,167 @@ class TestVMAXStorageDriver(TestCase):
             }
         }
 
-        expected_historic = [constants.MetricStruct(name='response_time',
-                                                    labels={
-                                                        'storage_id': '12345',
-                                                        'resource_type':
-                                                            'array'},
-                                                    values={
-                                                        1598875800000:
-                                                            9.1405992,
-                                                        1598876400000:
-                                                            9.2676263,
-                                                        1598876100000:
-                                                            9.1774695}
-                                                    ),
-                             constants.MetricStruct(name='throughput',
-                                                    labels={
-                                                        'storage_id': '12345',
-                                                        'resource_type':
-                                                            'array'},
-                                                    values={
-                                                        1598875800000: 296.1,
-                                                        1598876100000:
-                                                            350.22998,
-                                                        1598876400000:
-                                                            297.63333}
-                                                    ),
-                             constants.MetricStruct(name='read_throughput',
-                                                    labels={
-                                                        'storage_id': '12345',
-                                                        'resource_type':
-                                                            'array'},
-                                                    values={
-                                                        1598875800000:
-                                                            14.056666,
-                                                        1598876100000:
-                                                            13.213333,
-                                                        1598876400000:
-                                                            13.176666}
-                                                    ),
-                             constants.MetricStruct(name='write_throughput',
-                                                    labels={
-                                                        'storage_id': '12345',
-                                                        'resource_type':
-                                                            'array'},
-                                                    values={
-                                                        1598875800000: 25.78,
-                                                        1598876100000:
-                                                            45.97333,
-                                                        1598876400000:
-                                                            28.643333}
-                                                    ),
-                             constants.MetricStruct(name='bandwidth',
-                                                    labels={
-                                                        'storage_id': '12345',
-                                                        'resource_type':
-                                                            'array'},
-                                                    values={
-                                                        1598875800000:
-                                                        0.36879882999999997,
-                                                        1598876400000:
-                                                            0.293219385,
-                                                        1598876100000:
-                                                            0.446360664}
-                                                    ),
-                             constants.MetricStruct(name='read_bandwidth',
-                                                    labels={
-                                                        'storage_id': '12345',
-                                                        'resource_type':
-                                                            'array'},
-                                                    values={
-                                                        1598875800000:
-                                                            0.05016927,
-                                                        1598876100000:
-                                                            0.043291014,
-                                                        1598876400000:
-                                                            0.042753905}
-                                                    ),
-                             constants.MetricStruct(name='write_bandwidth',
-                                                    labels={
-                                                        'storage_id': '12345',
-                                                        'resource_type':
-                                                            'array'},
-                                                    values={
-                                                        1598875800000:
-                                                            0.31862956,
-                                                        1598876100000:
-                                                            0.40306965,
-                                                        1598876400000:
-                                                            0.25046548}
-                                                    )
-                             ]
+        expected_historic = [
+            constants.metric_struct(name='response_time',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type':
+                                            'array'},
+                                    values={
+                                        1598875800000:
+                                            9.1405992,
+                                        1598876400000:
+                                            9.2676263,
+                                        1598876100000:
+                                            9.1774695}
+                                    ),
+            constants.metric_struct(name='throughput',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type':
+                                            'array'},
+                                    values={
+                                        1598875800000: 296.1,
+                                        1598876100000:
+                                            350.22998,
+                                        1598876400000:
+                                            297.63333}
+                                    ),
+            constants.metric_struct(name='read_throughput',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type':
+                                            'array'},
+                                    values={
+                                        1598875800000:
+                                            14.056666,
+                                        1598876100000:
+                                            13.213333,
+                                        1598876400000:
+                                            13.176666}
+                                    ),
+            constants.metric_struct(name='write_throughput',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type':
+                                            'array'},
+                                    values={
+                                        1598875800000: 25.78,
+                                        1598876100000:
+                                            45.97333,
+                                        1598876400000:
+                                            28.643333}
+                                    ),
+            constants.metric_struct(name='bandwidth',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type':
+                                            'array'},
+                                    values={
+                                        1598875800000:
+                                            0.36879882999999997,
+                                        1598876400000:
+                                            0.293219385,
+                                        1598876100000:
+                                            0.446360664}
+                                    ),
+            constants.metric_struct(name='read_bandwidth',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type':
+                                            'array'},
+                                    values={
+                                        1598875800000:
+                                            0.05016927,
+                                        1598876100000:
+                                            0.043291014,
+                                        1598876400000:
+                                            0.042753905}
+                                    ),
+            constants.metric_struct(name='write_bandwidth',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type':
+                                            'array'},
+                                    values={
+                                        1598875800000:
+                                            0.31862956,
+                                        1598876100000:
+                                            0.40306965,
+                                        1598876400000:
+                                            0.25046548}
+                                    )
+        ]
 
         expected_realtime = [
-            constants.MetricStruct(name='response_time',
-                                   labels={
-                                       'storage_id': '12345',
-                                       'resource_type':
-                                           'array'},
-                                   values={
-                                       1598875800000:
-                                           9.1405992
-                                   }
-                                   ),
-            constants.MetricStruct(name='throughput',
-                                   labels={
-                                       'storage_id': '12345',
-                                       'resource_type':
-                                           'array'},
-                                   values={
-                                       1598875800000: 296.1
-                                   }
-                                   ),
-            constants.MetricStruct(name='read_throughput',
-                                   labels={
-                                       'storage_id': '12345',
-                                       'resource_type':
-                                           'array'},
-                                   values={
-                                       1598875800000:
-                                           14.056666
-                                   }
-                                   ),
-            constants.MetricStruct(name='write_throughput',
-                                   labels={
-                                       'storage_id': '12345',
-                                       'resource_type':
-                                           'array'},
-                                   values={
-                                       1598875800000: 25.78
-                                   }
-                                   ),
-            constants.MetricStruct(name='bandwidth',
-                                   labels={
-                                       'storage_id': '12345',
-                                       'resource_type':
-                                           'array'},
-                                   values={
-                                       1598875800000:
-                                           0.36879882999999997
-                                   }
-                                   ),
-            constants.MetricStruct(name='read_bandwidth',
-                                   labels={
-                                       'storage_id': '12345',
-                                       'resource_type':
-                                           'array'},
-                                   values={
-                                       1598875800000:
-                                           0.05016927
-                                   }
-                                   ),
-            constants.MetricStruct(name='write_bandwidth',
-                                   labels={
-                                       'storage_id': '12345',
-                                       'resource_type': 'array'
-                                   },
-                                   values={
-                                       1598875800000: 0.31862956
+            constants.metric_struct(name='response_time',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type':
+                                            'array'},
+                                    values={
+                                        1598875800000:
+                                            9.1405992
+                                    }
+                                    ),
+            constants.metric_struct(name='throughput',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type':
+                                            'array'},
+                                    values={
+                                        1598875800000: 296.1
+                                    }
+                                    ),
+            constants.metric_struct(name='read_throughput',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type':
+                                            'array'},
+                                    values={
+                                        1598875800000:
+                                            14.056666
+                                    }
+                                    ),
+            constants.metric_struct(name='write_throughput',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type':
+                                            'array'},
+                                    values={
+                                        1598875800000: 25.78
+                                    }
+                                    ),
+            constants.metric_struct(name='bandwidth',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type':
+                                            'array'},
+                                    values={
+                                        1598875800000:
+                                            0.36879882999999997
+                                    }
+                                    ),
+            constants.metric_struct(name='read_bandwidth',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type':
+                                            'array'},
+                                    values={
+                                        1598875800000:
+                                            0.05016927
+                                    }
+                                    ),
+            constants.metric_struct(name='write_bandwidth',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type': 'array'
+                                    },
+                                    values={
+                                        1598875800000: 0.31862956
 
-                                   }
-                                   )
+                                    }
+                                    )
         ]
 
         kwargs = VMAX_STORAGE_CONF


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Common framework required for VMAX driver to POST metrics request and parse it.
Array level metric collection for VMAX metrics.
                 [
                  "HostIOs",
                 "HostMBWritten",
                 "ReadResponseTime",
                 "HostMBReads",
                 "HostReads",
                 "HostWrites",
                 "WriteResponseTime"
                 ]
Which are used to map or derive unified Delfin metrics 
   "response_time",
    "throughput",
    "read_throughput",
    "write_throughput",
    "bandwidth",
    "read_bandwidth",
    "write_bandwidth"



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # NA

**Special notes for your reviewer**:
This is just driver side changes. Need to connect with task manager changes to test end to end.
This PR has been tested with real VMAX by doinf some tweeks in exisitng task manager to call this driver interface.
Unit test has been written to test this functionality

**Test Report**:
// POST request function output 
[performance_metric_query_output.txt](https://github.com/sodafoundation/delfin/files/5246507/performance_metric_query_output.txt)
// Driver reponse after prasing and adapting to delfin model

[driver_reponse.txt](https://github.com/sodafoundation/delfin/files/5246511/driver_reponse.txt)



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
