### PR TITLE
 Modifying some exception in VMAX and schema validation of ssh acces info

### DIFF
--- a/delfin/api/schemas/access_info.py
+++ b/delfin/api/schemas/access_info.py
@@ -43,7 +43,7 @@ update = {
                             'maxLength': 4096},
                 'pub_key_type': parameter_types.host_key_type
             },
-            'required': ['host', 'port', 'username', 'password', 'pub_key'],
+            'required': ['host', 'port', 'username'],
             'additionalProperties': False
         },
         'extra_attributes': {

--- a/delfin/api/views/alert_source.py
+++ b/delfin/api/views/alert_source.py
@@ -32,5 +32,4 @@ def build_alert_source(value):
     elif version.lower() == 'snmpv3':
         # Remove the key not belong to snmpv3
         view.pop('community_string')
-        pass
     return dict(view)

--- a/delfin/drivers/dell_emc/vmax/client.py
+++ b/delfin/drivers/dell_emc/vmax/client.py
@@ -47,7 +47,7 @@ class VMAXClient(object):
         try:
             ver, self.uni_version = self.rest.get_uni_version()
             LOG.info('Connected to Unisphere Version: {0}'.format(ver))
-        except exception.InvalidCredential as e:
+        except exception.InvalidUsernameOrPassword as e:
             msg = "Failed to connect VMAX. Reason: {}".format(e.msg)
             LOG.error(msg)
             raise e
@@ -61,7 +61,7 @@ class VMAXClient(object):
             msg = ("Failed to connect to VMAX. Host or Port is not correct: "
                    "{}".format(err))
             LOG.error(msg)
-            raise exception.HTTPConnectionTimeout(msg)
+            raise exception.InvalidIpOrPort()
 
         if not self.uni_version:
             msg = "Invalid input. Failed to get vmax unisphere version"

--- a/delfin/drivers/dell_emc/vmax/rest.py
+++ b/delfin/drivers/dell_emc/vmax/rest.py
@@ -117,8 +117,6 @@ class VMaxRest(object):
         session.mount("https://", ssl_utils.HostNameIgnoreAdapter())
 
         self.session = session
-        # Check whether the session be able to working
-        self.get_unisphere_version()
         return session
 
     def request(self, target_uri, method, params=None, request_object=None,
@@ -437,7 +435,7 @@ class VMaxRest(object):
                 pre_91_endpoint, GET, timeout=VERSION_GET_TIME_OUT)
 
         if status_code == STATUS_401:
-            raise exception.InvalidCredential()
+            raise exception.InvalidUsernameOrPassword()
 
         if not version_dict:
             LOG.error("Unisphere version info not found.")

--- a/delfin/exception.py
+++ b/delfin/exception.py
@@ -262,7 +262,7 @@ class InvalidCAPath(DelfinException):
     msg_fmt = _("Invalid CA path: {0}.")
 
 
-class SSLCertificateFailed(Invalid):
+class SSLCertificateFailed(DelfinException):
     msg_fmt = _("SSL Certificate Failed.")
     code = 400
 
@@ -280,5 +280,5 @@ class StorageIsSyncing(Invalid):
 
 
 class InvalidIpOrPort(DelfinException):
-    msg_fmt = _("Ip or Port Error.")
+    msg_fmt = _("Invalid ip or port.")
     code = 400

--- a/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
+++ b/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
@@ -63,15 +63,14 @@ class TestVMAXStorageDriver(TestCase):
         self.assertEqual(driver.client.array_id, "00112233")
 
         with self.assertRaises(Exception) as exc:
-            mock_version.side_effect = exception.StorageBackendException
+            mock_version.side_effect = exception.InvalidIpOrPort
             VMAXStorageDriver(**kwargs)
-        self.assertIn('Exception from Storage Backend', str(exc.exception))
+        self.assertIn('Invalid ip or port', str(exc.exception))
 
         with self.assertRaises(Exception) as exc:
-            mock_version.side_effect = ['V9.0.2.7', '90']
-            mock_array.side_effect = exception.StorageBackendException
+            mock_version.side_effect = exception.InvalidUsernameOrPassword
             VMAXStorageDriver(**kwargs)
-        self.assertIn('Failed to connect to VMAX', str(exc.exception))
+        self.assertIn('Invalid username or password.', str(exc.exception))
 
     @mock.patch.object(VMaxRest, 'get_system_capacity')
     @mock.patch.object(VMaxRest, 'get_vmax_array_details')


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Some improvemnts to the VMAX unisphere  exception  classification and ssh schema validation.
removed an unwanted pass from build alert source
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:
This is tested code with an integrated product, basic sanity done on opensource with fake driver.



**Test Report**:
all basic APIs executed
![image](https://user-images.githubusercontent.com/45681499/94365822-885f5700-00f1-11eb-9bcb-b0de5bd173a0.png)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
