### PR TITLE
Fixing config path to sync with ansible installer

### DIFF
--- a/delfin/common/config.py
+++ b/delfin/common/config.py
@@ -24,7 +24,6 @@ The idea is to move fully to cfg eventually, and this wrapper is a
 stepping stone.
 
 """
-import os
 import json
 import socket
 from delfin import exception
@@ -135,9 +134,7 @@ def set_middleware_defaults():
 
 def load_json_file(config_file):
     try:
-        abs_path = os.getcwd().split('/')[:-2]
-        scheduler_config = '/'.join(abs_path) + config_file
-        with open(scheduler_config) as f:
+        with open(config_file) as f:
             data = json.load(f)
             return data
     except json.decoder.JSONDecodeError as e:

--- a/etc/delfin/delfin.conf
+++ b/etc/delfin/delfin.conf
@@ -8,4 +8,4 @@ connection = sqlite:////var/lib/delfin/delfin.sqlite
 db_backend = sqlalchemy
 
 [scheduler]
-config_path = '/etc/scheduler_config.json'
+config_path = /etc/delfin/scheduler_config.json

--- a/installer/install_delfin.py
+++ b/installer/install_delfin.py
@@ -139,6 +139,11 @@ def main():
                                  'delfin', 'delfin.conf')
     copy_files(conf_file_src, conf_file)
 
+    # Copy the scheduler_config.json file
+    conf_file_src = os.path.join(delfin_source_path, 'etc',
+                                 'scheduler_config.json')
+    copy_files(conf_file_src, delfin_etc_dir)
+
     # install
     install_delfin()
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
To support ansible installer, we need to update config path. Becasue ansible has already pre-creating config working directry for all configuration. so we scheduler configuration should also go into same directory

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
