### PR TITLE
 Adding more labels to array leval metrics

### DIFF
--- a/delfin/exporter/prometheus.py
+++ b/delfin/exporter/prometheus.py
@@ -56,13 +56,17 @@ class PrometheusExporter(object):
                 labels = metric.labels
                 values = metric.values
                 storage_id = labels.get('storage_id')
+                storage_name = labels.get('name')
+                storage_sn = labels.get('serial_number')
                 resource_type = labels.get('resource_type')
                 unit = unit_of_metric.get(name)
                 value_type = labels.get('value_type', 'gauge')
                 storage_labels = (
-                    "storage_id=\"%s\",resource_type=\"%s\","
+                    "storage_id=\"%s\",storage_name=\"%s\",storage_sn=\"%s\","
+                    "resource_type=\"%s\", "
                     "type=\"%s\",unit=\"%s\",value_type=\"%s\"" %
-                    (storage_id, resource_type, 'RAW', unit, value_type))
+                    (storage_id, storage_name, storage_sn, resource_type,
+                     'RAW', unit, value_type))
 
                 self._write_to_prometheus_format(f, name, storage_labels,
                                                  values)

--- a/delfin/task_manager/tasks/resources.py
+++ b/delfin/task_manager/tasks/resources.py
@@ -272,6 +272,18 @@ class ArrayPerformanceCollection(PerformanceCollectionTask):
             array_metrics = self.driver_api.collect_array_metrics(
                 self.context, self.storage_id, self.interval,
                 self.is_historic)
+            # fill extra labels to metric by fetching metadata from resource DB
+            try:
+                array_details = db.storage_get(self.context, storage_id=self
+                                               .storage_id)
+                for m in array_metrics:
+                    m.labels["name"] = array_details.name
+                    m.labels["serial_number"] = array_details.serial_number
+
+            except Exception as e:
+                msg = _('Failed to add extra labels to array performance '
+                        'metrics: {0}'.format(e))
+                LOG.error(msg)
 
             self.perf_exporter.dispatch(self.context, array_metrics)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Array leval metrics from delfin has only storage_id (DB ID) to identify the storage , This is not enough for the client to identify storage in the dashbaords.
This change set is to fetch storage name and serial number from DB and attach it with metric labels.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #417 

**Special notes for your reviewer**:
NA
**Release note**:

1. Adding storage_name and storage_sn to array leval metric labels.

```release-note
```
**Test Report**:# TYPE storage_write_bandwidth gauge
storage_write_bandwidth{storage_id="f6090ae3-1f59-4a94-ad6a-7eaf507ddce8",storage_name="fake_driver",storage_sn="d579c957-86f6-44bd-829f-a6c01b732700",resource_type="array", type="RAW",unit="MBps",value_type="gauge"} 19.071724 1607419133466

