### PR TITLE
Fix resync issue

### DIFF
--- a/delfin/api/v1/storages.py
+++ b/delfin/api/v1/storages.py
@@ -217,4 +217,5 @@ def _set_synced_if_ok(context, storage_id, resource_count):
                 storage['sync_status'] > 0:
             raise exception.StorageIsSyncing(storage['id'])
         storage['sync_status'] = resource_count * constants.ResourceSync.START
+        storage['updated_at'] = current_time
         db.storage_update(context, storage['id'], storage)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Set update_at of the specific storage before starting to sync the storage.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #424 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```Test case
1. Send sync request, the request can be handled successfully
2. Send sync request, and before sync task is done, send the same request again, it throwed StorageIsSyncing exception
3. Send sync request after 30 mins of last sync task, and before sync task is done, send the same request again, it throwed StorageIsSyncing exception
4. Send sync request, and if sync task is not done after 30 mins, send the sync request again, the request can be handled.
```
