### PR TITLE
Driver list alert api enhancement

### DIFF
--- a/delfin/api/v1/alerts.py
+++ b/delfin/api/v1/alerts.py
@@ -61,7 +61,12 @@ class AlertController(wsgi.Controller):
             raise exception.InvalidInput(msg)
 
         storage = db.storage_get(ctx, id)
-        alert_list = self.driver_manager.list_alerts(ctx, id, query_para)
+
+        try:
+            alert_list = self.driver_manager.list_alerts(ctx, id, query_para)
+        except NotImplementedError:
+            msg = "Method not supported by the storage backend."
+            raise exception.MethodNotAllowed(msg)
 
         # Update storage attributes in each alert model
         for alert in alert_list:

--- a/delfin/drivers/driver.py
+++ b/delfin/drivers/driver.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import six
 import abc
+
+import six
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -93,8 +94,9 @@ class StorageDriver(object):
         query_para is an optional para which contains 'begin_time' and
         'end_time' (in milliseconds) which is to be used to filter
         alerts at driver
+        If not supported, NotImplementedError is expected to return
         """
-        pass
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def clear_alert(self, context, sequence_number):

--- a/delfin/exception.py
+++ b/delfin/exception.py
@@ -78,6 +78,11 @@ class NotAuthorized(DelfinException):
     code = 403
 
 
+class MethodNotAllowed(DelfinException):
+    msg_fmt = _("Method not allowed.")
+    code = 405
+
+
 class Invalid(DelfinException):
     msg_fmt = _("Unacceptable parameters.")
     code = 400

--- a/delfin/task_manager/tasks/alerts.py
+++ b/delfin/task_manager/tasks/alerts.py
@@ -51,6 +51,10 @@ class AlertSyncTask(object):
             self.alert_export_manager.dispatch(ctx, current_alert_list)
             LOG.info('Syncing storage alerts successful for storage id:{0}'
                      .format(storage_id))
+        except NotImplementedError:
+            msg = _('Not performed sync alerts as the method not supported by '
+                    'storage id:{0}'.format(storage_id))
+            LOG.info(msg)
         except Exception as e:
             msg = _('Failed to sync alerts from storage device: {0}'
                     .format(six.text_type(e)))

--- a/delfin/tests/unit/api/v1/test_alerts.py
+++ b/delfin/tests/unit/api/v1/test_alerts.py
@@ -50,6 +50,10 @@ def fake_storage_info():
     }
 
 
+def list_alert_exception(self, ctx, fake_storage_id, query_para):
+    raise NotImplementedError()
+
+
 class AlertControllerTestCase(unittest.TestCase):
     ALERT_CONTROLLER_CLASS = 'delfin.api.v1.alerts.AlertController'
 
@@ -140,5 +144,20 @@ class AlertControllerTestCase(unittest.TestCase):
         self.assertRaisesRegex(exception.InvalidInput, "end_time should be "
                                                        "greater than "
                                                        "begin_time",
+                               alert_controller_inst.show, req,
+                               fake_storage_id)
+
+    @mock.patch('delfin.db.storage_get')
+    @mock.patch('delfin.task_manager.rpcapi.TaskAPI', mock.Mock())
+    @mock.patch('delfin.drivers.api.API.list_alerts', list_alert_exception)
+    def test_list_alert_not_implemented(self, mock_fake_storage):
+        req = fakes.HTTPRequest.blank('/storages/fake_id/alerts')
+        req.GET['begin_time'] = '123400000'
+        req.GET['end_time'] = '123500000'
+        fake_storage_id = 'abcd-1234-5678'
+
+        mock_fake_storage.return_value = fake_storage_info()
+        alert_controller_inst = self._get_alert_controller()
+        self.assertRaisesRegex(exception.MethodNotAllowed, "",
                                alert_controller_inst.show, req,
                                fake_storage_id)

--- a/delfin/tests/unit/task_manager/test_alerts.py
+++ b/delfin/tests/unit/task_manager/test_alerts.py
@@ -1,0 +1,110 @@
+# Copyright 2020 The SODA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from oslo_utils import importutils
+
+
+def fake_alert_list():
+    return [{
+        'alert_id': '19660818',
+        'sequence_number': 10,
+        'alert_name': 'SNMP connect failed',
+        'category': 'Fault',
+        'severity': 'Major',
+        'type': 'OperationalViolation',
+        'location': 'NetworkEntity=storage1',
+        'description': "SNMP connection to the storage failed. "
+                       "SNMP traps from storage will not be received.",
+        'recovery_advice': "1. The network connection is abnormal. "
+                           "2. SNMP authentication parameters "
+                           "are invalid.",
+        'occur_time': 13445566900
+    }]
+
+
+def fake_storage_info(ctx, storage_id):
+    return {
+        'id': storage_id,
+        'name': 'storage1',
+        'vendor': 'fake vendor',
+        'model': 'fake model',
+        'serial_number': 'serial-1234',
+    }
+
+
+def empty_alert_list():
+    return []
+
+
+def list_alert_exception(self, ctx, fake_storage_id, query_para):
+    raise NotImplementedError()
+
+
+class TestAlertSyncTask(unittest.TestCase):
+    ALERT_TASK_CLASS = 'delfin.task_manager.tasks.alerts.AlertSyncTask'
+
+    def _get_alert_sync_task(self):
+        alert_task_class = importutils.import_class(
+            self.ALERT_TASK_CLASS)
+        alert_sync_task = alert_task_class()
+        return alert_sync_task
+
+    @mock.patch('delfin.db.storage_get', fake_storage_info)
+    @mock.patch('delfin.drivers.api.API.list_alerts')
+    @mock.patch('delfin.exporter.base_exporter.AlertExporterManager')
+    def test_sync_alerts(self, mock_alert_export, mock_list_alerts):
+        ctx = {}
+        query_para = {}
+        fake_storage_id = 'abcd-1234-5678'
+        mock_list_alerts.return_value = fake_alert_list()
+
+        alert_sync_task_inst = self._get_alert_sync_task()
+        alert_sync_task_inst.sync_alerts(ctx, fake_storage_id, query_para)
+        self.assertTrue(mock_alert_export.called)
+
+    @mock.patch('delfin.db.storage_get', fake_storage_info)
+    @mock.patch('delfin.drivers.api.API.list_alerts')
+    @mock.patch('delfin.common.alert_util.fill_storage_attributes')
+    def test_sync_alerts_empty(self, mock_fill_storage_attributes,
+                               mock_list_alerts):
+        ctx = {}
+        query_para = {}
+        fake_storage_id = 'abcd-1234-5678'
+        mock_list_alerts.return_value = empty_alert_list()
+
+        alert_sync_task_inst = self._get_alert_sync_task()
+        alert_sync_task_inst.sync_alerts(ctx, fake_storage_id, query_para)
+
+        # Verify that when no alerts, filling, exporting alert is not triggered
+        self.assertFalse(mock_fill_storage_attributes.called)
+
+    @mock.patch('delfin.db.storage_get', fake_storage_info)
+    @mock.patch('delfin.drivers.api.API.list_alerts',
+                list_alert_exception)
+    @mock.patch('delfin.db.storage_get', fake_storage_info)
+    @mock.patch('delfin.drivers.api.API.list_alerts', list_alert_exception)
+    @mock.patch('delfin.common.alert_util.fill_storage_attributes')
+    def test_sync_alerts_not_implemented(self, mock_fill_storage_attributes):
+        ctx = {}
+        query_para = {}
+        fake_storage_id = 'abcd-1234-5678'
+
+        alert_sync_task_inst = self._get_alert_sync_task()
+        alert_sync_task_inst.sync_alerts(ctx, fake_storage_id, query_para)
+
+        # Verify that during error, filling, exporting alert is not triggered
+        self.assertFalse(mock_fill_storage_attributes.called)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently List alert api of driver either returns queried alerts or return empty list if it fails to retrieve alerts
Some backends does not support querying alerts
Incase of failure to return alerts due to missing support from backend, empty alerts list is confusing to the consumer as they can not differentiate if it is failure case or actually no alerts at backend

In this implementation, new exception is supported.  
Incase driver do not support the implementation, it can be raised

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This PR is to address the issue mentioned in https://github.com/sodafoundation/delfin/issues/428

**Special notes for your reviewer**:
Test report (By simulating unsupported implementation with fake driver)

**Register storage flow:**
![image](https://user-images.githubusercontent.com/30930862/102330857-155ad380-3fb0-11eb-8214-a6175c6c232e.png)


![image](https://user-images.githubusercontent.com/30930862/102330947-315e7500-3fb0-11eb-8e70-e1c5f304fc4c.png)

**List alert flow:**
![image](https://user-images.githubusercontent.com/30930862/102591946-c9876600-4138-11eb-9d1e-0393cbd13393.png)



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
