### PR TITLE
Improvement for snmp validation

### DIFF
--- a/delfin/alert_manager/snmp_validator.py
+++ b/delfin/alert_manager/snmp_validator.py
@@ -45,7 +45,6 @@ class SNMPValidator(object):
             # engine id if engine id is empty. Therefore, engine id
             # should be saved in database.
             if not engine_id and alert_source.get('engine_id'):
-
                 alert_source_dict = {
                     'engine_id': alert_source.get('engine_id')}
                 db.alert_source_update(ctxt,
@@ -81,23 +80,34 @@ class SNMPValidator(object):
 
         cmd_gen = cmdgen.CommandGenerator()
 
-        # Register engine observer to get engineId,
-        # Code reference from: http://snmplabs.com/pysnmp/
-        observer_context = {}
-        cmd_gen.snmpEngine.observer.registerObserver(
-            lambda e, p, v, c: c.update(
-                securityEngineId=v['securityEngineId']),
-            'rfc3412.prepareDataElements:internal',
-            cbCtx=observer_context
-        )
-
         version = alert_source.get('version')
 
         # Connect to alert source through snmp get to check the configuration
         try:
+            target = cmdgen.UdpTransportTarget((alert_source['host'],
+                                                alert_source['port']),
+                                               timeout=alert_source[
+                                                   'expiration'],
+                                               retries=alert_source[
+                                                   'retry_num'])
+            target.setLocalAddress((CONF.my_ip, 0))
             if version.lower() == 'snmpv3':
-                auth_key = cryptor.decode(alert_source['auth_key'])
-                privacy_key = cryptor.decode(alert_source['privacy_key'])
+                # Register engine observer to get engineId,
+                # Code reference from: http://snmplabs.com/pysnmp/
+                observer_context = {}
+                cmd_gen.snmpEngine.observer.registerObserver(
+                    lambda e, p, v, c: c.update(
+                        securityEngineId=v['securityEngineId']),
+                    'rfc3412.prepareDataElements:internal',
+                    cbCtx=observer_context
+                )
+
+                auth_key = None
+                if alert_source['auth_key']:
+                    auth_key = cryptor.decode(alert_source['auth_key'])
+                privacy_key = None
+                if alert_source['privacy_key']:
+                    privacy_key = cryptor.decode(alert_source['privacy_key'])
                 auth_protocol = None
                 privacy_protocol = None
                 if alert_source['auth_protocol']:
@@ -117,12 +127,7 @@ class SNMPValidator(object):
                                        authProtocol=auth_protocol,
                                        privProtocol=privacy_protocol,
                                        securityEngineId=engine_id),
-                    cmdgen.UdpTransportTarget((alert_source['host'],
-                                               alert_source['port']),
-                                              timeout=alert_source[
-                                                  'expiration'],
-                                              retries=alert_source[
-                                                  'retry_num']),
+                    target,
                     constants.SNMP_QUERY_OID,
                 )
 
@@ -137,14 +142,11 @@ class SNMPValidator(object):
                     cmdgen.CommunityData(
                         community_string,
                         contextName=alert_source['context_name']),
-                    cmdgen.UdpTransportTarget((alert_source['host'],
-                                               alert_source['port']),
-                                              timeout=alert_source[
-                                                  'expiration'],
-                                              retries=alert_source[
-                                                  'retry_num']),
+                    target,
                     constants.SNMP_QUERY_OID,
                 )
+
+            cmd_gen.snmpEngine.transportDispatcher.closeDispatcher()
 
             if not error_indication:
                 return alert_source

--- a/delfin/alert_manager/snmp_validator.py
+++ b/delfin/alert_manager/snmp_validator.py
@@ -101,7 +101,6 @@ class SNMPValidator(object):
                     'rfc3412.prepareDataElements:internal',
                     cbCtx=observer_context
                 )
-
                 auth_key = None
                 if alert_source['auth_key']:
                     auth_key = cryptor.decode(alert_source['auth_key'])

--- a/delfin/task_manager/tasks/alerts.py
+++ b/delfin/task_manager/tasks/alerts.py
@@ -16,6 +16,7 @@ import six
 from oslo_log import log
 
 from delfin import db
+from delfin import exception
 from delfin.common import alert_util
 from delfin.drivers import api as driver_manager
 from delfin.exporter import base_exporter
@@ -66,6 +67,9 @@ class AlertSyncTask(object):
             try:
                 self.driver_manager.clear_alert(ctx, storage_id,
                                                 sequence_number)
+            except (exception.AccessInfoNotFound,
+                    exception.StorageNotFound) as e:
+                LOG.warning("Ignore the situation: %s", e.msg)
             except Exception as e:
                 LOG.error("Failed to clear alert with sequence number: %s "
                           "for storage: %s, reason: %s.",

--- a/delfin/tests/unit/alert_manager/fakes.py
+++ b/delfin/tests/unit/alert_manager/fakes.py
@@ -110,3 +110,24 @@ def mock_add_transport(snmpEngine, transportDomain, transport):
 
 def config_delv3_exception(snmp_engine, username, securityEngineId):
     raise exception.InvalidResults("Config delete failed.")
+
+
+def mock_cmdgen_get_cmd(self, authData, transportTarget, *varNames, **kwargs):
+    self.snmpEngine.transportDispatcher = AsyncoreDispatcher()
+    return None, None, None, None
+
+
+def fake_v2_alert_source():
+    return {'storage_id': 'abcd-1234-5678',
+            'version': 'snmpv2c',
+            'community_string': 'YWJjZDEyMzQ1Njc=',
+            }
+
+
+FAKE_STOTRAGE = {
+    'id': 1,
+    'name': 'fake_storage',
+    'vendor': 'fake_vendor',
+    'model': 'fake_model',
+    'serial_number': '12345678',
+}

--- a/delfin/tests/unit/alert_manager/test_snmp_validator.py
+++ b/delfin/tests/unit/alert_manager/test_snmp_validator.py
@@ -1,0 +1,135 @@
+# Copyright 2021 The SODA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import random
+from datetime import datetime
+from unittest import mock
+
+from pysnmp.entity.rfc3413.oneliner import cmdgen
+
+from delfin import context
+from delfin import db
+from delfin import test
+from delfin.alert_manager import snmp_validator
+from delfin.common import constants
+from delfin.exporter import base_exporter
+from delfin.tests.unit.alert_manager import fakes
+
+
+class TestSNMPValidator(test.TestCase):
+    @mock.patch.object(db, 'alert_source_update',
+                       mock.Mock())
+    @mock.patch('delfin.alert_manager.snmp_validator.'
+                'SNMPValidator.validate_connectivity')
+    def test_validate(self, mock_validate_connectivity):
+        validator = snmp_validator.SNMPValidator()
+
+        mock_validate_connectivity.return_value = fakes.fake_v3_alert_source()
+        v3_alert_source_without_engine_id = fakes.fake_v3_alert_source()
+        v3_alert_source_without_engine_id.pop('engine_id')
+        validator.validate(context, v3_alert_source_without_engine_id)
+        self.assertEqual(db.alert_source_update.call_count, 1)
+
+        mock_validate_connectivity.return_value = fakes.fake_v3_alert_source()
+        validator.validate(context,
+                           fakes.fake_v3_alert_source())
+        self.assertEqual(db.alert_source_update.call_count, 1)
+
+    @mock.patch.object(cmdgen.UdpTransportTarget, '_resolveAddr',
+                       mock.Mock())
+    @mock.patch.object(cmdgen.UdpTransportTarget, 'setLocalAddress',
+                       mock.Mock())
+    @mock.patch.object(cmdgen.CommandGenerator, 'getCmd',
+                       fakes.mock_cmdgen_get_cmd)
+    @mock.patch('pysnmp.entity.observer.MetaObserver.registerObserver')
+    @mock.patch('pysnmp.carrier.asyncore.dispatch.AbstractTransportDispatcher'
+                '.closeDispatcher')
+    def test_validate_connectivity(self, mock_close_dispatcher,
+                                   mock_register_observer):
+        # Get a random host
+        a = random.randint(0, 255)
+        b = random.randint(0, 255)
+        c = random.randint(0, 255)
+        d = random.randint(0, 255)
+        host = str(a) + '.' + str(b) + '.' + str(c) + '.' + str(d)
+        # Get a random port
+        port = random.randint(1024, 65535)
+        # snmpv3
+        v3_alert_source = fakes.fake_v3_alert_source()
+        v3_alert_source['host'] = host
+        v3_alert_source['port'] = port
+        snmp_validator.SNMPValidator.validate_connectivity(
+            v3_alert_source)
+        self.assertEqual(mock_close_dispatcher.call_count, 1)
+        self.assertEqual(mock_register_observer.call_count, 1)
+        # snmpv2c
+        v2_alert_source = fakes.fake_v2_alert_source()
+        v2_alert_source['host'] = host
+        v2_alert_source['port'] = port
+        snmp_validator.SNMPValidator.validate_connectivity(
+            v2_alert_source)
+        self.assertEqual(mock_close_dispatcher.call_count, 2)
+        self.assertEqual(mock_register_observer.call_count, 1)
+
+    @mock.patch.object(db, 'storage_get',
+                       mock.Mock(return_value=fakes.FAKE_STOTRAGE))
+    @mock.patch.object(snmp_validator.SNMPValidator,
+                       '_dispatch_snmp_validation_alert', mock.Mock())
+    def test_handle_validation_result(self):
+        validator = snmp_validator.SNMPValidator()
+
+        validator._handle_validation_result(
+            context, fakes.FAKE_STOTRAGE['id'],
+            constants.Category.FAULT)
+        snmp_validator.SNMPValidator._dispatch_snmp_validation_alert \
+            .assert_called_with(context,
+                                fakes.FAKE_STOTRAGE,
+                                constants.Category.FAULT)
+
+        validator._handle_validation_result(
+            context, fakes.FAKE_STOTRAGE['id'],
+            constants.Category.RECOVERY)
+        snmp_validator.SNMPValidator._dispatch_snmp_validation_alert \
+            .assert_called_with(context,
+                                fakes.FAKE_STOTRAGE,
+                                constants.Category.RECOVERY)
+
+    @mock.patch.object(base_exporter.AlertExporterManager, 'dispatch',
+                       mock.Mock())
+    def test_dispatch_snmp_validation_alert(self):
+        validator = snmp_validator.SNMPValidator()
+        storage = fakes.FAKE_STOTRAGE
+        alert = {
+            'storage_id': storage['id'],
+            'storage_name': storage['name'],
+            'vendor': storage['vendor'],
+            'model': storage['model'],
+            'serial_number': storage['serial_number'],
+            'alert_id': constants.SNMP_CONNECTION_FAILED_ALERT_ID,
+            'sequence_number': 0,
+            'alert_name': 'SNMP connect failed',
+            'category': constants.Category.FAULT,
+            'severity': constants.Severity.MAJOR,
+            'type': constants.EventType.COMMUNICATIONS_ALARM,
+            'location': 'NetworkEntity=%s' % storage['name'],
+            'description': "SNMP connection to the storage failed. "
+                           "SNMP traps from storage will not be received.",
+            'recovery_advice': "1. The network connection is abnormal. "
+                               "2. SNMP authentication parameters "
+                               "are invalid.",
+            'occur_time': int(datetime.utcnow().timestamp()) * 1000,
+        }
+        validator._dispatch_snmp_validation_alert(
+            context, storage, constants.Category.FAULT)
+        base_exporter.AlertExporterManager(). \
+            dispatch.assert_called_once_with(context, alert)

--- a/delfin/tests/unit/task_manager/test_alert_task.py
+++ b/delfin/tests/unit/task_manager/test_alert_task.py
@@ -1,0 +1,115 @@
+# Copyright 2021 The SODA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest import mock
+
+from delfin import context
+from delfin import db
+from delfin import exception
+from delfin import test
+from delfin.common import constants
+from delfin.task_manager.tasks import alerts
+
+fake_storage = {
+    'id': '12c2d52f-01bc-41f5-b73f-7abf6f38a2a6',
+    'name': 'fake_driver',
+    'description': 'it is a fake driver.',
+    'vendor': 'fake_vendor',
+    'model': 'fake_model',
+    'status': 'normal',
+    'serial_number': '2102453JPN12KA000011',
+    'firmware_version': '1.0.0',
+    'location': 'HK',
+    'total_capacity': 1024 * 1024,
+    'used_capacity': 3126,
+    'free_capacity': 1045449,
+}
+
+fake_alerts = [
+    {
+        'alert_id': '1050',
+        'alert_name': 'SAMPLE_ALERT_NAME',
+        'severity': constants.Severity.WARNING,
+        'category': constants.Category.NOT_SPECIFIED,
+        'type': constants.EventType.EQUIPMENT_ALARM,
+        'sequence_number': 79,
+        'description': 'Diagnostic event trace triggered.',
+        'recovery_advice': 'NA',
+        'resource_type': constants.DEFAULT_RESOURCE_TYPE,
+        'location': 'Array id=000192601409,Component type=location1 '
+                    'Group,Component name=comp1,Event source=symmetrix',
+    },
+    {
+        'alert_id': '2000',
+        'alert_name': 'SAMPLE_ALERT_NAME_2',
+        'severity': constants.Severity.CRITICAL,
+        'category': constants.Category.RECOVERY,
+        'type': constants.EventType.PROCESSING_ERROR_ALARM,
+        'sequence_number': 50,
+        'description': 'This is a fake alert.',
+        'recovery_advice': 'NA',
+        'resource_type': constants.DEFAULT_RESOURCE_TYPE,
+        'location': 'Array id=000192601409,Component type=location1 '
+                    'Group,Component name=comp1,Event source=symmetrix',
+    },
+]
+
+
+class TestAlertTask(test.TestCase):
+
+    @mock.patch.object(db, 'storage_get',
+                       mock.Mock(return_value=fake_storage))
+    @mock.patch('delfin.exporter.base_exporter.AlertExporterManager.dispatch')
+    @mock.patch('delfin.common.alert_util.fill_storage_attributes')
+    @mock.patch('delfin.drivers.api.API.list_alerts')
+    def test_sync_alerts(self, mock_list_alerts,
+                         mock_fill_storage_attributes, mock_dispatch):
+        task = alerts.AlertSyncTask()
+        storage_id = fake_storage['id']
+        # No alert
+        mock_list_alerts.return_value = []
+        task.sync_alerts(context, storage_id, None)
+        self.assertEqual(db.storage_get.call_count, 1)
+        self.assertEqual(mock_list_alerts.call_count, 1)
+        self.assertEqual(mock_dispatch.call_count, 0)
+        self.assertEqual(mock_fill_storage_attributes.call_count, 0)
+        # Has alert
+        mock_list_alerts.return_value = fake_alerts
+        task.sync_alerts(context, storage_id, None)
+        self.assertEqual(db.storage_get.call_count, 2)
+        self.assertEqual(mock_list_alerts.call_count, 2)
+        self.assertEqual(mock_dispatch.call_count, 1)
+        self.assertEqual(mock_fill_storage_attributes.call_count,
+                         len(fake_alerts))
+
+    @mock.patch('delfin.drivers.api.API.clear_alert')
+    def test_clear_alerts(self, mock_clear_alert):
+        task = alerts.AlertSyncTask()
+        storage_id = fake_storage['id']
+        task.clear_alerts(context, storage_id, [])
+        self.assertEqual(mock_clear_alert.call_count, 0)
+
+        sequence_number_list = ['sequence_number_1', 'sequence_number_2']
+        task.clear_alerts(context, storage_id, sequence_number_list)
+        self.assertEqual(mock_clear_alert.call_count,
+                         len(sequence_number_list))
+
+        mock_clear_alert.side_effect = \
+            exception.AccessInfoNotFound(storage_id)
+        ret = task.clear_alerts(context, storage_id, sequence_number_list)
+        self.assertEqual(ret, [])
+
+        mock_clear_alert.side_effect = \
+            exception.Invalid('Fake exception')
+        ret = task.clear_alerts(context, storage_id, sequence_number_list)
+        self.assertEqual(ret, sequence_number_list)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When `auth_key` and `privacy_key` is null string '', it should be considered as None

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #443 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
