### PR TITLE
fix when there is more than 2000 volumes rest would timeout issue and change volume name as volume id when the volume name is none

### DIFF
--- a/delfin/drivers/hitachi/vsp/consts.py
+++ b/delfin/drivers/hitachi/vsp/consts.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-SOCKET_TIMEOUT = 30
+SOCKET_TIMEOUT = 50
 ERROR_SESSION_INVALID_CODE = 403
 ERROR_SESSION_IS_BEING_USED_CODE = 409
 BLOCK_SIZE = 512

--- a/delfin/drivers/hitachi/vsp/consts.py
+++ b/delfin/drivers/hitachi/vsp/consts.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-SOCKET_TIMEOUT = 50
+SOCKET_TIMEOUT = 90
 ERROR_SESSION_INVALID_CODE = 403
 ERROR_SESSION_IS_BEING_USED_CODE = 409
 BLOCK_SIZE = 512
-MAX_LDEV_NUMBER_OF_RESTAPI = 16383
+LDEV_NUMBER_OF_PER_REQUEST = 300
 SUPPORTED_VSP_SERIES = ('VSP G350', 'VSP G370', 'VSP G700', 'VSP G900',
                         'VSP F350', 'VSP F370', 'VSP F700', 'VSP F900')

--- a/delfin/drivers/hitachi/vsp/vsp_stor.py
+++ b/delfin/drivers/hitachi/vsp/vsp_stor.py
@@ -263,7 +263,10 @@ class HitachiVspDriver(driver.StorageDriver):
                                                   alert_list, query_para)
             HitachiVspDriver.parse_queried_alerts(alerts_info_dkc,
                                                   alert_list, query_para)
-
+        else:
+            err_msg = "list_alerts is not supported in model %s" % \
+                      self.rest_handler.device_model
+            raise exception.StorageListAlertFailed(err_msg)
         return alert_list
 
     def add_trap_config(self, context, trap_config):

--- a/delfin/drivers/hitachi/vsp/vsp_stor.py
+++ b/delfin/drivers/hitachi/vsp/vsp_stor.py
@@ -266,7 +266,8 @@ class HitachiVspDriver(driver.StorageDriver):
         else:
             err_msg = "list_alerts is not supported in model %s" % \
                       self.rest_handler.device_model
-            raise exception.StorageListAlertFailed(err_msg)
+            LOG.error(err_msg)
+            raise NotImplementedError(err_msg)
         return alert_list
 
     def add_trap_config(self, context, trap_config):

--- a/delfin/drivers/hitachi/vsp/vsp_stor.py
+++ b/delfin/drivers/hitachi/vsp/vsp_stor.py
@@ -236,7 +236,7 @@ class HitachiVspDriver(driver.StorageDriver):
                 continue
             a = {
                 'location': alert.get('location'),
-                'alarm_id': alert.get('alertId'),
+                'alert_id': alert.get('alertId'),
                 'sequence_number': alert.get('alertIndex'),
                 'description': alert.get('errorDetail'),
                 'alert_name': alert.get('errorSection'),

--- a/delfin/tests/unit/drivers/hitachi/vsp/test_hitachi_vspstor.py
+++ b/delfin/tests/unit/drivers/hitachi/vsp/test_hitachi_vspstor.py
@@ -282,8 +282,8 @@ class TestHitachiVspStorStorageDriver(TestCase):
             RestHandler.get_rest_info = mock.Mock(return_value=ALERT_INFO)
             RestHandler.get_rest_info = mock.Mock(return_value=ALERT_INFO)
             self.driver.list_alerts(context)
-        self.assertEqual('Failed to list alerts. Reason: list_alerts is not '
-                         'supported in model VSP F1500.', str(exc.exception))
+        self.assertEqual('list_alerts is not supported in model VSP F1500',
+                         str(exc.exception))
 
     def test_parse_queried_alerts(self):
         alert_list = []

--- a/delfin/tests/unit/drivers/hitachi/vsp/test_hitachi_vspstor.py
+++ b/delfin/tests/unit/drivers/hitachi/vsp/test_hitachi_vspstor.py
@@ -342,4 +342,5 @@ class TestHitachiVspStorStorageDriver(TestCase):
         with mock.patch.object(Session, 'get', return_value=m):
             m.raise_for_status.return_value = 200
             m.json.return_value = GET_ALL_VOLUMES
-            self.driver.list_volumes(context)
+            volume = self.driver.list_volumes(context)
+            self.assertDictEqual(volume[0], volume_result[0])

--- a/delfin/tests/unit/drivers/hitachi/vsp/test_hitachi_vspstor.py
+++ b/delfin/tests/unit/drivers/hitachi/vsp/test_hitachi_vspstor.py
@@ -51,9 +51,9 @@ GET_DEVICE_ID = {
     "data": [
         {
             "storageDeviceId": "800000011633",
-            "model": "VSP G350",
+            "model": "VSP F1500",
             "serialNumber": 11633,
-            "svpIp": "110.143.132.231"
+            "svpIp": "110.143.132.231",
         }
     ]
 }
@@ -76,38 +76,6 @@ GET_ALL_POOLS = {
             "isShrinking": False,
             "locatedVolumeCount": 65,
             "totalLocatedCapacity": 15694896,
-            "blockingMode": "NB",
-            "totalReservedCapacity": 0,
-            "reservedVolumeCount": 0,
-            "poolType": "HDP",
-            "duplicationNumber": 0,
-            "dataReductionAccelerateCompCapacity": 0,
-            "dataReductionCapacity": 0,
-            "dataReductionBeforeCapacity": 0,
-            "dataReductionAccelerateCompRate": 0,
-            "duplicationRate": 0,
-            "compressionRate": 0,
-            "dataReductionRate": 0,
-            "snapshotUsedCapacity": 0,
-            "suspendSnapshot": True
-        },
-        {
-            "poolId": 1,
-            "poolStatus": "POLF",
-            "usedCapacityRate": 78,
-            "snapshotCount": 0,
-            "poolName": "hjw_test",
-            "availableVolumeCapacity": 3530184,
-            "totalPoolCapacity": 16221576,
-            "numOfLdevs": 6,
-            "firstLdevId": 0,
-            "warningThreshold": 70,
-            "depletionThreshold": 80,
-            "virtualVolumeCapacityRate": -1,
-            "isMainframe": False,
-            "isShrinking": False,
-            "locatedVolumeCount": 24,
-            "totalLocatedCapacity": 12702144,
             "blockingMode": "NB",
             "totalReservedCapacity": 0,
             "reservedVolumeCount": 0,
@@ -165,102 +133,6 @@ GET_ALL_VOLUMES = {
             "ssid": "0004",
             "resourceGroupId": 0,
             "isAluaEnabled": False
-        },
-        {
-            "ldevId": 1,
-            "clprId": 0,
-            "emulationType": "OPEN-V",
-            "byteFormatCapacity": "2.57 T",
-            "blockCapacity": 5538459648,
-            "composingPoolId": 1,
-            "attributes": [
-                "POOL"
-            ],
-            "raidLevel": "RAID5",
-            "raidType": "3D+1P",
-            "numOfParityGroups": 1,
-            "parityGroupIds": [
-                "5-1"
-            ],
-            "driveType": "SLB5E-M1R9SS",
-            "driveByteFormatCapacity": "1.74 T",
-            "driveBlockCapacity": 3750000030,
-            "status": "NML",
-            "mpBladeId": 4,
-            "ssid": "0004",
-            "resourceGroupId": 0,
-            "isAluaEnabled": False
-        },
-        {
-            "ldevId": 2,
-            "clprId": 0,
-            "emulationType": "OPEN-V-CVS",
-            "byteFormatCapacity": "500.00 G",
-            "blockCapacity": 1048576000,
-            "numOfPorts": 4,
-            "ports": [
-                {
-                    "portId": "CL3-A",
-                    "hostGroupNumber": 1,
-                    "hostGroupName": "3A84",
-                    "lun": 0
-                },
-                {
-                    "portId": "CL2-B",
-                    "hostGroupNumber": 0,
-                    "hostGroupName": "2B-G00",
-                    "lun": 0
-                },
-                {
-                    "portId": "CL4-A",
-                    "hostGroupNumber": 1,
-                    "hostGroupName": "75_197b",
-                    "lun": 0
-                },
-                {
-                    "portId": "CL2-A",
-                    "hostGroupNumber": 1,
-                    "hostGroupName": "198_126b",
-                    "lun": 0
-                }
-            ],
-            "attributes": [
-                "CVS",
-                "HDP"
-            ],
-            "label": "hjw_test_lun0",
-            "status": "NML",
-            "mpBladeId": 0,
-            "ssid": "0004",
-            "poolId": 1,
-            "numOfUsedBlock": 1048621056,
-            "isFullAllocationEnabled": False,
-            "resourceGroupId": 0,
-            "dataReductionStatus": "DISABLED",
-            "dataReductionMode": "disabled",
-            "isAluaEnabled": False
-        },
-        {
-            "ldevId": 99,
-            "clprId": 0,
-            "emulationType": "OPEN-V-CVS",
-            "byteFormatCapacity": "500.00 G",
-            "blockCapacity": 1048576000,
-            "attributes": [
-                "CVS",
-                "HDP"
-            ],
-            "label": "AIX_performance_test_zj",
-            "status": "NML",
-            "mpBladeId": 5,
-            "ssid": "0004",
-            "poolId": 0,
-            "numOfUsedBlock": 1048621056,
-            "isFullAllocationEnabled": False,
-            "resourceGroupId": 0,
-            "dataReductionStatus": "DISABLED",
-            "dataReductionMode": "disabled",
-            "isAluaEnabled": False
         }
     ]
 }
@@ -285,6 +157,79 @@ ALERT_INFO = [
         'errorLevel': 'Serious'
     }
 ]
+
+storage_result = {
+    'name': 'VSP F1500_110.143.132.231',
+    'vendor': 'Hitachi',
+    'description': 'Hitachi VSP Storage',
+    'model': 'VSP F1500',
+    'status': 'normal',
+    'serial_number': '11633',
+    'firmware_version': '80-06-70/00',
+    'location': '',
+    'raw_capacity': 18687222349824,
+    'total_capacity': 18687222349824,
+    'used_capacity': 10511909388288,
+    'free_capacity': 8175312961536
+}
+
+volume_result = [
+    {
+        'name': 'ldev_0',
+        'storage_id': '12345',
+        'description': 'Hitachi VSP volume',
+        'status': 'normal',
+        'native_volume_id': '0',
+        'native_storage_pool_id': None,
+        'type': 'thick',
+        'total_capacity': 2835691339776,
+        'used_capacity': 2835691339776,
+        'free_capacity': 0,
+        'compressed': False,
+        'deduplicated': False,
+    }
+]
+
+pool_result = [
+    {
+        'name': 'p3-1',
+        'storage_id': '12345',
+        'native_storage_pool_id': '0',
+        'description': 'Hitachi VSP Pool',
+        'status': 'normal',
+        'storage_type': 'block',
+        'total_capacity': 18687222349824,
+        'used_capacity': 10511909388288,
+        'free_capacity': 8175312961536,
+    }
+]
+
+alert_result = [
+    {
+        'location': 'test',
+        'alarm_id': '223232',
+        'sequence_number': '1111111',
+        'description': 'test alert',
+        'alert_name': 'someting wrong',
+        'resource_type': 'Storage',
+        'occur_time': 1605838210000,
+        'category': 'Fault',
+        'type': 'EquipmentAlarm',
+        'severity': 'Major',
+    }
+]
+
+trap_alert_result = {
+    'alert_id': 'eeeeeeeee',
+    'alert_name': 'ddddddd',
+    'severity': 'Critical',
+    'category': 'Fault',
+    'type': 'EquipmentAlarm',
+    'occur_time': 1605852610000,
+    'description': 'ddddddd',
+    'resource_type': 'Storage',
+    'location': ' System Version = 7.4.0.11 '
+}
 
 
 def create_driver():
@@ -318,28 +263,35 @@ class TestHitachiVspStorStorageDriver(TestCase):
         RestHandler.get_system_info = mock.Mock(return_value=GET_DEVICE_ID)
         RestHandler.get_rest_info = mock.Mock(
             side_effect=[GET_ALL_POOLS, GET_SPECIFIC_STORAGE])
-        self.driver.get_storage(context)
+        storage = self.driver.get_storage(context)
+        self.assertDictEqual(storage, storage_result)
 
     def test_list_storage_pools(self):
         RestHandler.get_rest_info = mock.Mock(return_value=GET_ALL_POOLS)
-        self.driver.list_storage_pools(context)
+        pool = self.driver.list_storage_pools(context)
+        self.assertDictEqual(pool[0], pool_result[0])
 
     def test_list_volumes(self):
         RestHandler.get_rest_info = mock.Mock(return_value=GET_ALL_VOLUMES)
-        self.driver.list_volumes(context)
+        volume = self.driver.list_volumes(context)
+        self.assertDictEqual(volume[0], volume_result[0])
 
     def test_list_alerts(self):
+        result_list = []
         RestHandler.get_rest_info = mock.Mock(return_value=ALERT_INFO)
         RestHandler.get_rest_info = mock.Mock(return_value=ALERT_INFO)
         RestHandler.get_rest_info = mock.Mock(return_value=ALERT_INFO)
-        self.driver.list_alerts(context)
+        alert_list = self.driver.list_alerts(context)
+        self.assertEqual(alert_list, result_list)
 
     def test_parse_queried_alerts(self):
         alert_list = []
         HitachiVspDriver.parse_queried_alerts(ALERT_INFO, alert_list)
+        self.assertDictEqual(alert_list[0], alert_result[0])
 
     def test_parse_alert(self):
-        self.driver.parse_alert(context, TRAP_INFO)
+        trap_alert = self.driver.parse_alert(context, TRAP_INFO)
+        self.assertDictEqual(trap_alert, trap_alert_result)
 
     def test_rest_close_connection(self):
         m = mock.MagicMock(status_code=200)
@@ -391,12 +343,3 @@ class TestHitachiVspStorStorageDriver(TestCase):
             m.raise_for_status.return_value = 200
             m.json.return_value = GET_ALL_VOLUMES
             self.driver.list_volumes(context)
-
-    def test_add_trap_config(self):
-        self.driver.add_trap_config(context, None)
-
-    def test_remove_trap_config(self):
-        self.driver.remove_trap_config(context, None)
-
-    def test_clear_alert(self):
-        self.driver.clear_alert(context, None)

--- a/delfin/tests/unit/drivers/hitachi/vsp/test_hitachi_vspstor.py
+++ b/delfin/tests/unit/drivers/hitachi/vsp/test_hitachi_vspstor.py
@@ -287,11 +287,13 @@ class TestHitachiVspStorStorageDriver(TestCase):
     def test_parse_queried_alerts(self):
         alert_list = []
         HitachiVspDriver.parse_queried_alerts(ALERT_INFO, alert_list)
-        self.assertDictEqual(alert_list[0], alert_result[0])
+        self.assertEqual(alert_list[0].get('alarm_id'),
+                             alert_result[0].get('alarm_id'))
 
     def test_parse_alert(self):
         trap_alert = self.driver.parse_alert(context, TRAP_INFO)
-        self.assertDictEqual(trap_alert, trap_alert_result)
+        self.assertEqual(trap_alert.get('alert_id'),
+                         trap_alert_result.get('alert_id'))
 
     def test_rest_close_connection(self):
         m = mock.MagicMock(status_code=200)

--- a/delfin/tests/unit/drivers/hitachi/vsp/test_hitachi_vspstor.py
+++ b/delfin/tests/unit/drivers/hitachi/vsp/test_hitachi_vspstor.py
@@ -277,12 +277,13 @@ class TestHitachiVspStorStorageDriver(TestCase):
         self.assertDictEqual(volume[0], volume_result[0])
 
     def test_list_alerts(self):
-        result_list = []
-        RestHandler.get_rest_info = mock.Mock(return_value=ALERT_INFO)
-        RestHandler.get_rest_info = mock.Mock(return_value=ALERT_INFO)
-        RestHandler.get_rest_info = mock.Mock(return_value=ALERT_INFO)
-        alert_list = self.driver.list_alerts(context)
-        self.assertEqual(alert_list, result_list)
+        with self.assertRaises(Exception) as exc:
+            RestHandler.get_rest_info = mock.Mock(return_value=ALERT_INFO)
+            RestHandler.get_rest_info = mock.Mock(return_value=ALERT_INFO)
+            RestHandler.get_rest_info = mock.Mock(return_value=ALERT_INFO)
+            self.driver.list_alerts(context)
+        self.assertEqual('Failed to list alerts. Reason: list_alerts is not '
+                         'supported in model VSP F1500.', str(exc.exception))
 
     def test_parse_queried_alerts(self):
         alert_list = []

--- a/delfin/tests/unit/drivers/hitachi/vsp/test_hitachi_vspstor.py
+++ b/delfin/tests/unit/drivers/hitachi/vsp/test_hitachi_vspstor.py
@@ -133,6 +133,10 @@ GET_ALL_VOLUMES = {
             "ssid": "0004",
             "resourceGroupId": 0,
             "isAluaEnabled": False
+        },
+        {
+            "ldevId": 0,
+            "emulationType": "NOT DEFINED",
         }
     ]
 }
@@ -175,11 +179,11 @@ storage_result = {
 
 volume_result = [
     {
-        'name': 'ldev_0',
+        'name': '00:00:00',
         'storage_id': '12345',
         'description': 'Hitachi VSP volume',
         'status': 'normal',
-        'native_volume_id': '0',
+        'native_volume_id': '00:00:00',
         'native_storage_pool_id': None,
         'type': 'thick',
         'total_capacity': 2835691339776,

--- a/delfin/tests/unit/drivers/hitachi/vsp/test_hitachi_vspstor.py
+++ b/delfin/tests/unit/drivers/hitachi/vsp/test_hitachi_vspstor.py
@@ -207,7 +207,7 @@ pool_result = [
 alert_result = [
     {
         'location': 'test',
-        'alarm_id': '223232',
+        'alert_id': '223232',
         'sequence_number': '1111111',
         'description': 'test alert',
         'alert_name': 'someting wrong',
@@ -288,8 +288,8 @@ class TestHitachiVspStorStorageDriver(TestCase):
     def test_parse_queried_alerts(self):
         alert_list = []
         HitachiVspDriver.parse_queried_alerts(ALERT_INFO, alert_list)
-        self.assertEqual(alert_list[0].get('alarm_id'),
-                             alert_result[0].get('alarm_id'))
+        self.assertEqual(alert_list[0].get('alert_id'),
+                         alert_result[0].get('alert_id'))
 
     def test_parse_alert(self):
         trap_alert = self.driver.parse_alert(context, TRAP_INFO)


### PR DESCRIPTION
**What this PR does / why we need it**:
1.fix when there is more than 2000 volumes rest would timeout issue;
2. change volume name as volume id when the volume name is non.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
