### PR TITLE
Performance collection unregistration during storage deletion

### DIFF
--- a/delfin/tests/unit/api/v1/test_storages.py
+++ b/delfin/tests/unit/api/v1/test_storages.py
@@ -22,6 +22,15 @@ from delfin import test
 from delfin.api.v1.storages import StorageController
 from delfin.tests.unit.api import fakes
 
+fake_schedular_config = {
+    "storages": [{"id": "fake_id",
+                  "array_polling": {"perf_collection": True, "interval": 12,
+                                    "is_historic": True}}]}
+
+invalid_schedular_config = '"storages": [{"id": "fake_id","array_polling": {' \
+                           '"perf_collection": True, "interval": 12,' \
+                           '"is_historic": True}}]} '
+
 
 class TestStorageController(test.TestCase):
 
@@ -35,8 +44,24 @@ class TestStorageController(test.TestCase):
 
     @mock.patch.object(db, 'storage_get',
                        mock.Mock(return_value={'id': 'fake_id'}))
-    def test_delete(self):
+    @mock.patch('delfin.common.config.load_json_file')
+    def test_delete(self, mock_load_json_file):
         req = fakes.HTTPRequest.blank('/storages/fake_id')
+        mock_load_json_file.return_value = fake_schedular_config
+        self.controller.delete(req, 'fake_id')
+        ctxt = req.environ['delfin.context']
+        db.storage_get.assert_called_once_with(ctxt, 'fake_id')
+        self.task_rpcapi.remove_storage_resource.assert_called_with(
+            ctxt, 'fake_id', mock.ANY)
+        self.task_rpcapi.remove_storage_in_cache.assert_called_once_with(
+            ctxt, 'fake_id')
+
+    @mock.patch.object(db, 'storage_get',
+                       mock.Mock(return_value={'id': 'fake_id'}))
+    @mock.patch('delfin.common.config.load_json_file')
+    def test_delete_invalid_schedular_conf(self, mock_load_json_file):
+        req = fakes.HTTPRequest.blank('/storages/fake_id')
+        mock_load_json_file.return_value = invalid_schedular_config
         self.controller.delete(req, 'fake_id')
         ctxt = req.environ['delfin.context']
         db.storage_get.assert_called_once_with(ctxt, 'fake_id')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR addresses Performance collection unregistration during storage deletion
Currently 2 issues observed during storage deletion
1) Performance job created for the storage is not deleted when storage is deleted
2) Schedular config json file entry is not deleted when storage is deleted

This PR addresses these issues

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/sodafoundation/delfin/issues/440

**Special notes for your reviewer**:
One improvement is suggested on current performance collection. 
To be tracked as part of below issue
https://github.com/sodafoundation/delfin/issues/450

**Detailed test report**
**Storage registration for performance collection:**
![image](https://user-images.githubusercontent.com/30930862/103632044-c9c19700-4f69-11eb-8809-a10fe0680625.png)

![image](https://user-images.githubusercontent.com/30930862/103632051-cb8b5a80-4f69-11eb-8767-2f3cfd816557.png)

**Performance collection unregistration during storage delete**
![image](https://user-images.githubusercontent.com/30930862/103632071-d1813b80-4f69-11eb-9dd8-8fc6e17e131d.png)


**Restart after storage delete and no stale performance collection tasks:**
![image](https://user-images.githubusercontent.com/30930862/103632101-d940e000-4f69-11eb-9dd1-4dd6a2263d4c.png)


**Registration of multiple storages and unregistration of one storage:**
![image](https://user-images.githubusercontent.com/30930862/103632123-de9e2a80-4f69-11eb-8b74-4608b5fa4064.png)

![image](https://user-images.githubusercontent.com/30930862/103632132-e231b180-4f69-11eb-930e-b97dab5f1a3a.png)

**Deletion of storage which is not registered for performance collection**
![image](https://user-images.githubusercontent.com/30930862/103632154-e78efc00-4f69-11eb-9acf-c13777cc57ea.png)

**Deletion of storage with some config file issue:**
![image](https://user-images.githubusercontent.com/30930862/103632172-ec53b000-4f69-11eb-8467-a666c601d030.png)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
