### PR TITLE
fix alert_fouction issue and change storage rawsize

### DIFF
--- a/delfin/drivers/dell_emc/unity/rest_handler.py
+++ b/delfin/drivers/dell_emc/unity/rest_handler.py
@@ -35,7 +35,6 @@ class RestHandler(RestClient):
     REST_LUNS_URL = '/api/types/lun/instances'
     REST_ALERTS_URL = '/api/types/alert/instances'
     REST_DEL_ALERTS_URL = '/api/instances/alert/'
-    REST_DISK_URL = '/api/types/disk/instances'
     REST_SOFT_VERSION_URL = '/api/types/installedSoftwareVersion/instances'
     REST_AUTH_KEY = 'EMC-CSRF-TOKEN'
 
@@ -189,13 +188,7 @@ class RestHandler(RestClient):
         result_json = self.get_rest_info(url)
         return result_json
 
-    def get_disk_info(self):
-        url = '%s?%s' % (RestHandler.REST_DISK_URL,
-                         'fields=rawSize')
-        result_json = self.get_rest_info(url)
-        return result_json
-
     def remove_alert(self, alert_id):
-        url = RestHandler.REST_DEL_ALERTS_URL % alert_id
+        url = '%s%s' % (RestHandler.REST_DEL_ALERTS_URL, alert_id)
         result_json = self.get_rest_info(url, method='DELETE')
         return result_json

--- a/delfin/drivers/dell_emc/unity/rest_handler.py
+++ b/delfin/drivers/dell_emc/unity/rest_handler.py
@@ -191,4 +191,6 @@ class RestHandler(RestClient):
     def remove_alert(self, alert_id):
         url = '%s%s' % (RestHandler.REST_DEL_ALERTS_URL, alert_id)
         result_json = self.get_rest_info(url, method='DELETE')
+        if result_json is not None:
+            raise exception.InvalidResults()
         return result_json

--- a/delfin/drivers/dell_emc/unity/unity.py
+++ b/delfin/drivers/dell_emc/unity/unity.py
@@ -186,4 +186,4 @@ class UNITYStorDriver(driver.StorageDriver):
         return AlertHandler.parse_alert(context, alert)
 
     def clear_alert(self, context, alert):
-        return self.rest_handler.remove_alert(context, alert)
+        return self.rest_handler.remove_alert(alert)

--- a/delfin/drivers/dell_emc/unity/unity.py
+++ b/delfin/drivers/dell_emc/unity/unity.py
@@ -41,7 +41,6 @@ class UNITYStorDriver(driver.StorageDriver):
         system_info = self.rest_handler.get_storage()
         capacity = self.rest_handler.get_capacity()
         version_info = self.rest_handler.get_soft_version()
-        disk_info = self.rest_handler.get_disk_info()
         status = constants.StorageStatus.OFFLINE
         if system_info is not None and capacity is not None:
             system_entries = system_info.get('entries')
@@ -66,11 +65,6 @@ class UNITYStorDriver(driver.StorageDriver):
             for soft_info in soft_version:
                 version = soft_info.get('content').get('id')
                 break
-            disk_entrier = disk_info.get('entries')
-            raw = 0
-            for disk in disk_entrier:
-                raw = raw + int(disk.get('content').get('rawSize'))
-
             result = {
                 'name': name,
                 'vendor': 'DELL EMC',
@@ -81,7 +75,7 @@ class UNITYStorDriver(driver.StorageDriver):
                 'location': '',
                 'subscribed_capacity': int(subs),
                 'total_capacity': int(total),
-                'raw_capacity': int(raw),
+                'raw_capacity': int(total),
                 'used_capacity': int(used),
                 'free_capacity': int(free)
             }

--- a/delfin/tests/unit/drivers/dell_emc/unity/test_emc_unity.py
+++ b/delfin/tests/unit/drivers/dell_emc/unity/test_emc_unity.py
@@ -596,9 +596,9 @@ class TestUNITYStorDriver(TestCase):
         alert_id = 101
         mock_call.return_value = 'remove alert fail'
         with self.assertRaises(Exception) as exc:
-            self.driver.rest_handler.remove_alert(alert_id)
+            self.driver.clear_alert(context, alert_id)
         self.assertIn('The results are invalid. {0}',
                       str(exc.exception))
         mock_call.return_value = None
-        re = self.driver.rest_handler.remove_alert(alert_id)
+        re = self.driver.clear_alert(context, alert_id)
         self.assertIsNone(re)

--- a/delfin/tests/unit/drivers/dell_emc/unity/test_emc_unity.py
+++ b/delfin/tests/unit/drivers/dell_emc/unity/test_emc_unity.py
@@ -581,8 +581,6 @@ class TestUNITYStorDriver(TestCase):
 
     def test_reset_connection(self):
         kwargs = ACCESS_INFO
-        self.assertEqual(self.driver.rest_handler.rest_host, "110.143.132.231")
-        self.assertEqual(self.driver.rest_handler.rest_port, "8443")
         with self.assertRaises(Exception) as exc:
             self.driver.reset_connection(context, **kwargs)
         self.assertIn('Bad response from server', str(exc.exception))
@@ -593,9 +591,14 @@ class TestUNITYStorDriver(TestCase):
         self.assertIn('Bad response from server',
                       str(exc.exception))
 
-    @mock.patch.object(RestHandler, 'remove_alert')
-    def test_clear_alert(self, mock_remove):
+    @mock.patch.object(RestHandler, 'get_rest_info')
+    def test_clear_alert(self, mock_call):
         alert_id = 101
-        mock_remove.return_value = None
-        re = self.driver.clear_alert(context, alert_id)
+        mock_call.return_value = 'remove alert fail'
+        with self.assertRaises(Exception) as exc:
+            self.driver.rest_handler.remove_alert(alert_id)
+        self.assertIn('The results are invalid. {0}',
+                      str(exc.exception))
+        mock_call.return_value = None
+        re = self.driver.rest_handler.remove_alert(alert_id)
         self.assertIsNone(re)

--- a/delfin/tests/unit/drivers/dell_emc/unity/test_emc_unity.py
+++ b/delfin/tests/unit/drivers/dell_emc/unity/test_emc_unity.py
@@ -593,8 +593,9 @@ class TestUNITYStorDriver(TestCase):
         self.assertIn('Bad response from server',
                       str(exc.exception))
 
-    def test_clear_alert(self):
+    @mock.patch.object(RestHandler, 'remove_alert')
+    def test_clear_alert(self, mock_remove):
         alert_id = 101
-        with self.assertRaises(Exception) as exc:
-            self.driver.clear_alert(context, alert_id)
-        self.assertIn('Bad response from server', str(exc.exception))
+        mock_remove.return_value = None
+        re = self.driver.clear_alert(context, alert_id)
+        self.assertIsNone(re)

--- a/delfin/tests/unit/drivers/dell_emc/unity/test_emc_unity.py
+++ b/delfin/tests/unit/drivers/dell_emc/unity/test_emc_unity.py
@@ -562,6 +562,7 @@ class TestUNITYStorDriver(TestCase):
         self.assertEqual(trap.get('alert_id'), trap_result.get('alert_id'))
 
     def test_rest_close_connection(self):
+        self.driver.close_connection()
         m = mock.MagicMock(status_code=200)
         with mock.patch.object(Session, 'post', return_value=m):
             m.raise_for_status.return_value = 200
@@ -580,16 +581,12 @@ class TestUNITYStorDriver(TestCase):
         self.assertIn('Bad response from server', str(exc.exception))
 
     def test_reset_connection(self):
-        RestHandler.logout = mock.Mock(return_value={})
-        m = mock.MagicMock(status_code=200)
-        with mock.patch.object(Session, 'get', return_value=m):
-            m.raise_for_status.return_value = 201
-            m.json.return_value = {
-                "EMC-CSRF-TOKEN": "97c13b8082444b36bc2103026205fa64"
-            }
-            kwargs = ACCESS_INFO
-            re = self.driver.reset_connection(context, **kwargs)
-            self.assertIsNone(re)
+        kwargs = ACCESS_INFO
+        self.assertEqual(self.driver.rest_handler.rest_host, "110.143.132.231")
+        self.assertEqual(self.driver.rest_handler.rest_port, "8443")
+        with self.assertRaises(Exception) as exc:
+            self.driver.reset_connection(context, **kwargs)
+        self.assertIn('Bad response from server', str(exc.exception))
 
     def test_err_storage_pools(self):
         with self.assertRaises(Exception) as exc:
@@ -599,9 +596,6 @@ class TestUNITYStorDriver(TestCase):
 
     def test_clear_alert(self):
         alert_id = 101
-        m = mock.MagicMock(status_code=200)
-        with mock.patch.object(Session, 'delete', return_value=m):
-            m.raise_for_status.return_value = 200
-            m.json.return_value = None
-            re = self.driver.clear_alert(context, alert_id)
-            self.assertIsNone(re)
+        with self.assertRaises(Exception) as exc:
+            self.driver.clear_alert(context, alert_id)
+        self.assertIn('Bad response from server', str(exc.exception))

--- a/delfin/tests/unit/drivers/dell_emc/unity/test_emc_unity.py
+++ b/delfin/tests/unit/drivers/dell_emc/unity/test_emc_unity.py
@@ -421,7 +421,7 @@ storage_result = {
     'status': 'abnormal',
     'name': 'CETV3182000026',
     'model': 'Unity 350F',
-    'raw_capacity': 2311766147072,
+    'raw_capacity': 8838774259712,
     'firmware_version': '4.7.1'
 }
 pool_result = [
@@ -532,8 +532,7 @@ class TestUNITYStorDriver(TestCase):
 
     def test_get_storage(self):
         RestHandler.get_rest_info = mock.Mock(
-            side_effect=[GET_STORAGE, GET_CAPACITY, GET_SOFT_VERSION,
-                         GET_DISK_INFO])
+            side_effect=[GET_STORAGE, GET_CAPACITY, GET_SOFT_VERSION])
         storage = self.driver.get_storage(context)
         self.assertDictEqual(storage, storage_result)
 
@@ -597,3 +596,12 @@ class TestUNITYStorDriver(TestCase):
             self.driver.list_storage_pools(context)
         self.assertIn('Bad response from server',
                       str(exc.exception))
+
+    def test_clear_alert(self):
+        alert_id = 101
+        m = mock.MagicMock(status_code=200)
+        with mock.patch.object(Session, 'delete', return_value=m):
+            m.raise_for_status.return_value = 200
+            m.json.return_value = None
+            re = self.driver.clear_alert(context, alert_id)
+            self.assertIsNone(re)

--- a/delfin/tests/unit/drivers/dell_emc/unity/test_emc_unity.py
+++ b/delfin/tests/unit/drivers/dell_emc/unity/test_emc_unity.py
@@ -562,7 +562,6 @@ class TestUNITYStorDriver(TestCase):
         self.assertEqual(trap.get('alert_id'), trap_result.get('alert_id'))
 
     def test_rest_close_connection(self):
-        self.driver.close_connection()
         m = mock.MagicMock(status_code=200)
         with mock.patch.object(Session, 'post', return_value=m):
             m.raise_for_status.return_value = 200


### PR DESCRIPTION
**What this PR does / why we need it**:
1.fix alert_fouction issue and add it's test;
2.change storage rawsize which can not get from api now replace with total,because in api,there is no raw_capacity,there just return sizeFree,sizeTotal,sizeUsed,sizeSubscribed capacity,they are not raw_capacity.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
