### PR TITLE
Fix for travis CI issue on cryptography dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ tooz>=1.58.0 # Apache-2.0
 WebOb>=1.7.1 # MIT
 pysnmp>=4.4.11 # BSD
 redis>=3.3.8 # MIT
+cryptography<3.4;python_version<"3.7" # Apache-2.0
 pyopenssl==19.1.0 # Apache-2.0
 APScheduler~=3.6.3
 flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ tooz>=1.58.0 # Apache-2.0
 WebOb>=1.7.1 # MIT
 pysnmp>=4.4.11 # BSD
 redis>=3.3.8 # MIT
-cryptography<3.4;python_version<"3.7" # Apache-2.0
+cryptography<3.4; # Apache-2.0
 pyopenssl==19.1.0 # Apache-2.0
 APScheduler~=3.6.3
 flask


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
A bump in the cryptography indirect dependency lead to cascading breaking changes in our direct dependency pyopenssl. This PR fixes this by directing adding cryptography to our requirements.txt and reverting to a previous cryptography version.

RCA
---
Newly added cryptography package requires rust compiler . 
For more reading about the rust problem in new cryptography version you can read in their github page : pyca/cryptography#5771

Due to this existing travis CI build  is failed. reported by some other open source community too 
some references 
https://github.com/cyberark/conjur-api-python3/pull/183
https://github.com/plotly/dash/pull/1551

In delfin we have cryptography package dependency with pyopenssl . pyopenssl version we use is 19.1 , which supports crypto version 2.8 or above .  problematic cryptography version is 3.4.1 

Solution
-----
Issue only seems problematic on Python 3.6  .  We can attempt use required cryptography version on python 3.6 

 




**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
NA
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
