### PR TITLE
Update Device delete operation by adding Telemetry task delete

### DIFF
--- a/delfin/api/v1/storages.py
+++ b/delfin/api/v1/storages.py
@@ -32,6 +32,7 @@ from delfin.drivers import api as driverapi
 from delfin.i18n import _
 from delfin.task_manager import rpcapi as task_rpcapi
 from delfin.task_manager.tasks import resources
+from delfin.task_manager.tasks import telemetry as task_telemetry
 
 LOG = log.getLogger(__name__)
 CONF = cfg.CONF
@@ -141,6 +142,13 @@ class StorageController(wsgi.Controller):
                 ctxt,
                 storage['id'],
                 subclass.__module__ + '.' + subclass.__name__)
+
+        for subclass in task_telemetry.TelemetryTask.__subclasses__():
+            self.task_rpcapi.remove_telemetry_instances(ctxt,
+                                                        storage['id'],
+                                                        subclass.__module__ +
+                                                        '.'
+                                                        + subclass.__name__)
         self.task_rpcapi.remove_storage_in_cache(ctxt, storage['id'])
 
     @wsgi.response(202)

--- a/delfin/db/api.py
+++ b/delfin/db/api.py
@@ -834,3 +834,10 @@ def failed_task_delete(context, failed_task_id):
     exist.
     """
     return IMPL.failed_task_delete(context, failed_task_id)
+
+
+def failed_task_delete_by_storage(context, storage_id):
+    """Delete all failed tasks of given storage or raise an exception if it
+    does not exist.
+    """
+    return IMPL.failed_task_delete_by_storage(context, storage_id)

--- a/delfin/db/sqlalchemy/api.py
+++ b/delfin/db/sqlalchemy/api.py
@@ -1723,7 +1723,9 @@ def task_get(context, tasks_id):
 
 def task_delete_by_storage(context, storage_id):
     """Delete all the tasks of a storage device"""
-    _task_get_query(context).filter_by(storage_id=storage_id).delete()
+    delete_info = {'deleted': True, 'deleted_at': timeutils.utcnow()}
+    _task_get_query(context).filter_by(
+        storage_id=storage_id).update(delete_info)
 
 
 def task_delete(context, tasks_id):
@@ -1808,6 +1810,13 @@ def failed_task_delete_by_task_id(context, task_id):
     """Delete all the failed tasks of a given task id"""
     _failed_tasks_get_query(context).filter_by(
         task_id=task_id).delete()
+
+
+def failed_task_delete_by_storage(context, storage_id):
+    """Delete all the failed tasks of a storage device"""
+    delete_info = {'deleted': True, 'deleted_at': timeutils.utcnow()}
+    _failed_tasks_get_query(context).filter_by(
+        storage_id=storage_id).update(delete_info)
 
 
 def failed_task_delete(context, failed_task_id):

--- a/delfin/db/sqlalchemy/models.py
+++ b/delfin/db/sqlalchemy/models.py
@@ -267,17 +267,22 @@ class Task(BASE, DelfinBase):
     args = Column(JsonEncodedDict)
     last_run_time = Column(Integer)
     job_id = Column(String(36))
+    deleted_at = Column(DateTime)
+    deleted = Column(Boolean, default=False)
 
 
 class FailedTask(BASE, DelfinBase):
     """Represents a failed task attributes."""
     __tablename__ = 'failed_tasks'
     id = Column(Integer, primary_key=True, autoincrement=True)
+    storage_id = Column(String(36))
     task_id = Column(Integer)
     interval = Column(Integer)
     start_time = Column(Integer)
     end_time = Column(Integer)
     retry_count = Column(Integer)
     method = Column(String(255))
-    job_id = Column(String(36))
     result = Column(String(255))
+    job_id = Column(String(36))
+    deleted_at = Column(DateTime)
+    deleted = Column(Boolean, default=False)

--- a/delfin/task_manager/manager.py
+++ b/delfin/task_manager/manager.py
@@ -63,6 +63,14 @@ class TaskManager(manager.Manager):
         drivers = driver_manager.DriverManager()
         drivers.remove_driver(storage_id)
 
+    def remove_telemetry_instances(self, context, storage_id, telemetry_task):
+        LOG.info('Remove telemetry instances for storage id:{0}')
+        cls = importutils.import_class(telemetry_task)
+        device_obj = cls()
+        return device_obj.remove_telemetry(context,
+                                           storage_id,
+                                           )
+
     def sync_storage_alerts(self, context, storage_id, query_para):
         LOG.info('Alert sync called for storage id:{0}'
                  .format(storage_id))

--- a/delfin/task_manager/rpcapi.py
+++ b/delfin/task_manager/rpcapi.py
@@ -71,6 +71,13 @@ class TaskAPI(object):
                                  'remove_storage_in_cache',
                                  storage_id=storage_id)
 
+    def remove_telemetry_instances(self, context, storage_id, telemetry_task):
+        call_context = self.client.prepare(version='1.0', fanout=True)
+        return call_context.cast(context,
+                                 'remove_telemetry_instances',
+                                 storage_id=storage_id,
+                                 telemetry_task=telemetry_task)
+
     def sync_storage_alerts(self, context, storage_id, query_para):
         call_context = self.client.prepare(version='1.0')
         return call_context.cast(context,

--- a/delfin/task_manager/scheduler/schedulers/telemetry/failed_telemetry_job.py
+++ b/delfin/task_manager/scheduler/schedulers/telemetry/failed_telemetry_job.py
@@ -41,8 +41,7 @@ class FailedTelemetryJob(object):
         :return:
         """
         try:
-            # Remove jobs from scheduler for deleted failed_tasks
-            # Remove jobs from scheduler if it is added
+            # Remove jobs from scheduler when marked for delete
             filters = {'deleted': True}
             failed_tasks = db.failed_task_get_all(self.ctx, filters=filters)
             LOG.debug("Total failed_tasks found deleted "
@@ -56,7 +55,7 @@ class FailedTelemetryJob(object):
             LOG.error("Failed to remove periodic scheduling job , reason: %s.",
                       six.text_type(e))
         try:
-            # create the object of periodic scheduler
+            # Create the object of periodic scheduler
             failed_tasks = db.failed_task_get_all(self.ctx)
 
             if not len(failed_tasks):

--- a/delfin/task_manager/scheduler/schedulers/telemetry/failed_telemetry_job.py
+++ b/delfin/task_manager/scheduler/schedulers/telemetry/failed_telemetry_job.py
@@ -41,11 +41,11 @@ class FailedTelemetryJob(object):
         :return:
         """
         try:
-            # Remove jobs from scheduler  for deleted failed_tasks
+            # Remove jobs from scheduler for deleted failed_tasks
             # Remove jobs from scheduler if it is added
             filters = {'deleted': True}
             failed_tasks = db.failed_task_get_all(self.ctx, filters=filters)
-            LOG.debug(" total failed_tasks found deleted "
+            LOG.debug("Total failed_tasks found deleted "
                       "in this cycle:%s" % len(failed_tasks))
             for failed_task in failed_tasks:
                 job_id = failed_task['job_id']

--- a/delfin/task_manager/scheduler/schedulers/telemetry/telemetry_job.py
+++ b/delfin/task_manager/scheduler/schedulers/telemetry/telemetry_job.py
@@ -42,11 +42,11 @@ class TelemetryJob(object):
     def __call__(self, ctx):
         """ Schedule the collection tasks based on interval """
         try:
-            # Remove jobs from scheduler  for deleted tasks
+            # Remove jobs from scheduler for deleted tasks
             # Remove jobs from scheduler if it is added
             filters = {'deleted': True}
             tasks = db.task_get_all(ctx, filters=filters)
-            LOG.debug(" total tasks found deleted "
+            LOG.debug("Total tasks found deleted "
                       "in this cycle:%s" % len(tasks))
             for task in tasks:
                 job_id = task['job_id']

--- a/delfin/task_manager/scheduler/schedulers/telemetry/telemetry_job.py
+++ b/delfin/task_manager/scheduler/schedulers/telemetry/telemetry_job.py
@@ -42,8 +42,7 @@ class TelemetryJob(object):
     def __call__(self, ctx):
         """ Schedule the collection tasks based on interval """
         try:
-            # Remove jobs from scheduler for deleted tasks
-            # Remove jobs from scheduler if it is added
+            # Remove jobs from scheduler when marked for delete
             filters = {'deleted': True}
             tasks = db.task_get_all(ctx, filters=filters)
             LOG.debug("Total tasks found deleted "

--- a/delfin/task_manager/tasks/telemetry.py
+++ b/delfin/task_manager/tasks/telemetry.py
@@ -31,6 +31,10 @@ class TelemetryTask(object):
     def collect(self, ctx, storage_id, args, start_time, end_time):
         pass
 
+    @abc.abstractmethod
+    def remove_telemetry(self, ctx, storage_id):
+        pass
+
 
 class PerformanceCollectionTask(TelemetryTask):
     def __init__(self):
@@ -66,3 +70,12 @@ class PerformanceCollectionTask(TelemetryTask):
                       "storage id :{0}, reason:{1}".format(storage_id,
                                                            six.text_type(e)))
             return TelemetryTaskStatus.TASK_EXEC_STATUS_FAILURE
+
+    def remove_telemetry(self, ctx, storage_id):
+        try:
+            db.task_delete_by_storage(ctx, storage_id)
+            db.failed_task_delete_by_storage(ctx, storage_id)
+        except Exception as e:
+            LOG.error("Failed to remove task entries from DB  for "
+                      "storage id :{0}, reason:{1}".format(storage_id,
+                                                           six.text_type(e)))

--- a/delfin/tests/unit/api/v1/test_storages.py
+++ b/delfin/tests/unit/api/v1/test_storages.py
@@ -41,6 +41,8 @@ class TestStorageController(test.TestCase):
         db.storage_get.assert_called_once_with(ctxt, 'fake_id')
         self.task_rpcapi.remove_storage_resource.assert_called_with(
             ctxt, 'fake_id', mock.ANY)
+        self.task_rpcapi.remove_telemetry_instances.assert_called_once_with(
+            ctxt, 'fake_id', mock.ANY)
         self.task_rpcapi.remove_storage_in_cache.assert_called_once_with(
             ctxt, 'fake_id')
 

--- a/delfin/tests/unit/db/test_db_api.py
+++ b/delfin/tests/unit/db/test_db_api.py
@@ -829,3 +829,12 @@ class TestSIMDBAPI(test.TestCase):
             .failed_task_delete_by_task_id(context,
                                            fake_failed_task_id)
         assert result is None
+
+    @mock.patch('delfin.db.sqlalchemy.api.get_session')
+    def test_failed_task_delete_by_storage(self, mock_session):
+        fake_failed_task_storage_id = [models.FailedTask().storage_id]
+        mock_session.return_value.__enter__.return_value.query.return_value \
+            = fake_failed_task_storage_id
+        result = db_api \
+            .task_delete_by_storage(context, fake_failed_task_storage_id)
+        assert result is None

--- a/delfin/tests/unit/task_manager/test_telemetry.py
+++ b/delfin/tests/unit/task_manager/test_telemetry.py
@@ -70,3 +70,16 @@ class TestPerformanceCollectionTask(test.TestCase):
         # when collect metric fails
         self.assertEqual(mock_dispatch.call_count, 0)
         self.assertEqual(mock_log_error.call_count, 1)
+
+    @mock.patch('delfin.db.failed_task_delete_by_storage')
+    @mock.patch('delfin.db.task_delete_by_storage')
+    def test_successful_remove(self, mock_task_del, mock_failed_task_del):
+        telemetry_obj = telemetry.PerformanceCollectionTask(
+        )
+        telemetry_obj.remove_telemetry(
+            context, 'c5c91c98-91aa-40e6-85ac-37a1d3b32bda')
+
+        mock_task_del.assert_called_with(
+            context, 'c5c91c98-91aa-40e6-85ac-37a1d3b32bda')
+        mock_failed_task_del.assert_called_with(
+            context, 'c5c91c98-91aa-40e6-85ac-37a1d3b32bda')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Addition of Performance collection introduced 2 new tables in DB .
While deleting a device we need to mark entries in those tables corresponds to the storage_id of deleting device as  'deleted'
This information is required by the periodic schedulers to cleanup jobs.

 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
1. This PR has dependency with performance trigger and scheduler change PRs. Filenames and class names may need to change according to those changes. 
2. This is a soft delete. currently we are not handling the hard delete of storage table, and task table entries. which has to be taken as periodic job, which will be taken later.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
