### PR TITLE
Fix importlib-metadata dependency for python 3.6 and 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ pyopenssl==19.1.0 # Apache-2.0
 APScheduler~=3.6.3
 flask
 kafka-python
+importlib-metadata==3.7.0; python_version < "3.8"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix importlib-metadata dependency for python 3.6 and 3.7


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Latest version of imported module `importlib-metadata` is failing on python 3.6 and python 3.7
Python 3.8 do not require these module (https://importlib-metadata.readthedocs.io/en/latest/)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
