### PR TITLE
Performance collection expiry handling for deleted storage

### DIFF
--- a/delfin/task_manager/scheduler/schedulers/telemetry/failed_telemetry_job.py
+++ b/delfin/task_manager/scheduler/schedulers/telemetry/failed_telemetry_job.py
@@ -50,7 +50,7 @@ class FailedTelemetryJob(object):
                 job_id = failed_task['job_id']
                 if job_id and self.scheduler.get_job(job_id):
                     self.scheduler.remove_job(job_id)
-                db.task_delete(self.ctx, failed_task['id'])
+                db.failed_task_delete(self.ctx, failed_task['id'])
         except Exception as e:
             LOG.error("Failed to remove periodic scheduling job , reason: %s.",
                       six.text_type(e))

--- a/delfin/tests/unit/task_manager/scheduler/schedulers/telemetry/test_failed_performance_collection_handler.py
+++ b/delfin/tests/unit/task_manager/scheduler/schedulers/telemetry/test_failed_performance_collection_handler.py
@@ -19,14 +19,15 @@ from oslo_utils import uuidutils
 
 from delfin import context
 from delfin import db
+from delfin import exception
 from delfin import test
 from delfin.common.constants import TelemetryCollection
+from delfin.common.constants import TelemetryTaskStatus, TelemetryJobStatus
 from delfin.db.sqlalchemy.models import FailedTask
 from delfin.db.sqlalchemy.models import Task
 from delfin.task_manager.scheduler.schedulers.telemetry. \
     failed_performance_collection_handler import \
     FailedPerformanceCollectionHandler
-from delfin.common.constants import TelemetryTaskStatus, TelemetryJobStatus
 
 fake_failed_job_id = 43
 
@@ -42,6 +43,22 @@ fake_failed_job = {
     FailedTask.start_time.name: int(datetime.now().timestamp()),
     FailedTask.end_time.name: int(datetime.now().timestamp()) + 20,
     FailedTask.interval.name: 20,
+    FailedTask.deleted.name: False,
+}
+
+fake_deleted_storage_failed_job = {
+    FailedTask.id.name: fake_failed_job_id,
+    FailedTask.retry_count.name: 0,
+    FailedTask.result.name: "Init",
+    FailedTask.job_id.name: uuidutils.generate_uuid(),
+    FailedTask.task_id.name: uuidutils.generate_uuid(),
+    FailedTask.method.name: FailedPerformanceCollectionHandler.__module__ +
+                            '.' +
+                            FailedPerformanceCollectionHandler.__name__,
+    FailedTask.start_time.name: int(datetime.now().timestamp()),
+    FailedTask.end_time.name: int(datetime.now().timestamp()) + 20,
+    FailedTask.interval.name: 20,
+    FailedTask.deleted.name: True,
 }
 
 fake_telemetry_job = {
@@ -49,6 +66,10 @@ fake_telemetry_job = {
     Task.storage_id.name: uuidutils.generate_uuid(),
     Task.args.name: {},
 }
+
+
+def failed_task_not_found_exception(ctx, failed_task_id):
+    raise exception.FailedTaskNotFound("Failed Task not found.")
 
 
 class TestFailedPerformanceCollectionHandler(test.TestCase):
@@ -143,3 +164,43 @@ class TestFailedPerformanceCollectionHandler(test.TestCase):
                     TelemetryCollection.MAX_FAILED_JOB_RETRY_COUNT,
                 FailedTask.result.name:
                     TelemetryJobStatus.FAILED_JOB_STATUS_INIT})
+
+    @mock.patch.object(db, 'task_get',
+                       mock.Mock(return_value=fake_telemetry_job))
+    @mock.patch.object(db, 'failed_task_get',
+                       mock.Mock(return_value=fake_deleted_storage_failed_job))
+    @mock.patch(
+        'apscheduler.schedulers.background.BackgroundScheduler.pause_job')
+    @mock.patch('delfin.db.failed_task_update')
+    @mock.patch('delfin.task_manager.rpcapi.TaskAPI.collect_telemetry')
+    def test_failed_job_deleted_storage(self, mock_collect_telemetry,
+                                        mock_failed_task_update,
+                                        mock_pause_job):
+        ctx = context.get_admin_context()
+        failed_job_handler = FailedPerformanceCollectionHandler.get_instance(
+            ctx, fake_failed_job_id)
+        failed_job_handler()
+
+        # Verify that no action performed for deleted storage failed tasks
+        self.assertEqual(mock_collect_telemetry.call_count, 0)
+        self.assertEqual(mock_failed_task_update.call_count, 0)
+
+    @mock.patch.object(db, 'task_get',
+                       mock.Mock(return_value=fake_telemetry_job))
+    @mock.patch.object(db, 'failed_task_get', failed_task_not_found_exception)
+    @mock.patch(
+        'apscheduler.schedulers.background.BackgroundScheduler.pause_job',
+        mock.Mock())
+    @mock.patch('delfin.db.failed_task_update')
+    @mock.patch('delfin.task_manager.rpcapi.TaskAPI.collect_telemetry')
+    def test_deleted_storage_exception(self, mock_collect_telemetry,
+                                       mock_failed_task_update):
+        ctx = context.get_admin_context()
+        failed_job_handler = FailedPerformanceCollectionHandler(
+            ctx, 1122, '12c2d52f-01bc-41f5-b73f-7abf6f38a2a6', '',
+            1234, 2, 1122334400, 1122334800)
+        failed_job_handler()
+
+        # Verify that no action performed for deleted storage failed tasks
+        self.assertEqual(mock_collect_telemetry.call_count, 0)
+        self.assertEqual(mock_failed_task_update.call_count, 0)

--- a/delfin/tests/unit/task_manager/scheduler/schedulers/telemetry/test_failed_telemetry_job.py
+++ b/delfin/tests/unit/task_manager/scheduler/schedulers/telemetry/test_failed_telemetry_job.py
@@ -41,6 +41,7 @@ fake_failed_job = {
     FailedTask.start_time.name: int(datetime.now().timestamp()),
     FailedTask.end_time.name: int(datetime.now().timestamp()) + 20,
     FailedTask.interval.name: 20,
+    FailedTask.deleted.name: False,
 }
 
 fake_failed_jobs = [
@@ -90,7 +91,7 @@ class TestFailedTelemetryJob(test.TestCase):
         failed_job()
 
         # entry get deleted and job get removed
-        self.assertEqual(mock_failed_task_delete.call_count, 1)
+        self.assertEqual(mock_failed_task_delete.call_count, 2)
         self.assertEqual(mock_remove_job.call_count, 1)
 
     @mock.patch(
@@ -132,5 +133,5 @@ class TestFailedTelemetryJob(test.TestCase):
         failed_job()
 
         # entry get deleted and job get removed
-        self.assertEqual(mock_failed_task_delete.call_count, 1)
+        self.assertEqual(mock_failed_task_delete.call_count, 2)
         self.assertEqual(mock_remove_job.call_count, 1)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
**Issue:** When performance collection is going on, if storage is deleted, collection will be marked for delete.
In next periodic cycle, cleanup will be done
But in current implementation, if collection cycle is triggered before cleanup cycle, collection and export is tried which will fail. This is unnecessary.
Similar scenario is applicable for the failed collection tasks as well.

**Fix:** When storage is marked for delete, if collection cycle is triggered, just ignore the trigger. 
In next periodic cycle, cleanup will be done normally


**Special notes for your reviewer**:
Testcases tested:
1) Delete storage, wait for performance collection expiry, make sure driver performance collection not triggered
1) Delete storage, wait for failed performance collection expiry, make sure driver performance collection not retried

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
