### PR TITLE
Emc vnx block:Modify alarm query

### DIFF
--- a/delfin/drivers/dell_emc/vnx/vnx_block/alert_handler.py
+++ b/delfin/drivers/dell_emc/vnx/vnx_block/alert_handler.py
@@ -35,7 +35,8 @@ class AlertHandler(object):
     def parse_alert(alert):
         try:
             alert_model = dict()
-            alert_model['alert_id'] = alert.get(consts.OID_MESSAGECODE)
+            alert_model['alert_id'] = AlertHandler.check_event_code(
+                alert.get(consts.OID_MESSAGECODE))
             alert_model['alert_name'] = alert.get(consts.OID_DETAILS)
             alert_model['severity'] = consts.TRAP_LEVEL_MAP.get(
                 alert.get(consts.OID_SEVERITY),
@@ -58,7 +59,8 @@ class AlertHandler(object):
         alert_list = []
         for alert in alerts:
             alert_model = {
-                'alert_id': alert.get('event_code'),
+                'alert_id': AlertHandler.check_event_code(
+                    alert.get('event_code')),
                 'alert_name': alert.get('message'),
                 'severity': consts.SEVERITY_MAP.get(
                     alert.get('event_code')[0:2]),
@@ -122,3 +124,9 @@ class AlertHandler(object):
             err_msg = "remove duplication failed: %s" % (six.text_type(e))
             LOG.error(err_msg)
             raise exception.InvalidResults(err_msg)
+
+    @staticmethod
+    def check_event_code(event_code):
+        if '0x' not in event_code:
+            event_code = '0x%s' % event_code
+        return event_code

--- a/delfin/drivers/dell_emc/vnx/vnx_block/consts.py
+++ b/delfin/drivers/dell_emc/vnx/vnx_block/consts.py
@@ -36,6 +36,7 @@ CER_SEPARATE_KEY = '-----------------------------'
 TIME_PATTERN = '%m/%d/%Y %H:%M:%S'
 DATE_PATTERN = '%m/%d/%Y'
 ONE_DAY_SCE = 24 * 60 * 60
+SECS_OF_QUERY_TIME_RANGE_DAYS = 29 * 24 * 60 * 60 * 1000
 LOG_FILTER_PATTERN = '\\(7[0-7]([a-f]|[0-9]){2}\\)'
 NAVISECCLI_API = 'naviseccli -User %(username)s -password %(password)s' \
                  ' -scope 0 -t %(timeout)d -h %(host)s'
@@ -68,8 +69,8 @@ VOL_TYPE_MAP = {'no': constants.VolumeType.THICK,
                 'yes': constants.VolumeType.THIN}
 VOL_COMPRESSED_MAP = {'no': False,
                       'yes': True}
-DEFAULT_QUERY_LOG_DAYS = 9
-SECS_OF_TEN_DAYS = DEFAULT_QUERY_LOG_DAYS * ONE_DAY_SCE
+DEFAULT_QUERY_LOG_DAYS = 3650
+SECS_OF_DEFAULT_QUERY_LOG_DAYS = DEFAULT_QUERY_LOG_DAYS * ONE_DAY_SCE
 OID_SEVERITY = '1.3.6.1.6.3.1.1.4.1.0'
 OID_MESSAGECODE = '1.3.6.1.4.1.1981.1.4.5'
 OID_DETAILS = '1.3.6.1.4.1.1981.1.4.6'

--- a/delfin/tests/unit/drivers/dell_emc/vnx/vnx_block/test_vnx_block.py
+++ b/delfin/tests/unit/drivers/dell_emc/vnx/vnx_block/test_vnx_block.py
@@ -11,8 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import sys
 from unittest import TestCase, mock
 
+sys.modules['delfin.cryptor'] = mock.Mock()
 from delfin import context
 from delfin.drivers.dell_emc.vnx.vnx_block.navi_handler import NaviHandler
 from delfin.drivers.dell_emc.vnx.vnx_block.navicli_client import NaviClient
@@ -98,6 +100,7 @@ LOG_INFOS = """
 OTHER_LOG_INFOS = """
 03/25/2020 00:13:03 N/A                  (4600)'Capture the array configurati
 03/25/2020 13:30:17 N/A                  (76cc)Navisphere Agent, version 7.33
+09/14/2020 20:03:25 N/A                  (7606)Thinpool (Migration_pool) is (
 """
 
 AGENT_RESULT = {
@@ -192,7 +195,7 @@ VOLUMES_RESULT = [
     }]
 ALERTS_RESULT = [
     {
-        'alert_id': '76cc',
+        'alert_id': '0x76cc',
         'alert_name': 'Navisphere Agent, version 7.33',
         'severity': 'Critical',
         'category': 'Fault',
@@ -214,7 +217,7 @@ ALERTS_RESULT = [
         'match_key': '65a5b90e11842a2aedf3bfab471f7701'
     }]
 ALERT_RESULT = {
-    'alert_id': '761f',
+    'alert_id': '0x761f',
     'alert_name': 'Unisphere can no longer manage',
     'severity': 'Critical',
     'category': 'Fault',


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1.Check if event_code contains '0x'
2.Modify the time parameter of alarm query.
3.The default query time range for modifying alarms is 3650 days.
4.If the query time range is more than 30 days, the query will be conducted in different time periods. The principle of query first in the latest time is adopted when querying. If there is no query result returned, the query will exit directly

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Check if event_code contains '0x'

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
