### PR TITLE
Add physical and logical type for disk

### DIFF
--- a/delfin/common/constants.py
+++ b/delfin/common/constants.py
@@ -131,9 +131,19 @@ class DiskPhysicalType(object):
     SAS = 'sas'
     SSD = 'ssd'
     NL_SSD = 'nl-ssd'
+    FC = 'fc'
+    LUN = 'lun'
+    ATA = 'ata'
+    FLASH = 'flash'
+    VMDISK = 'vmdisk'
+    NL_SAS = 'nl-sas'
+    SSD_CARD = 'ssd-card'
+    SAS_FLASH_VP = 'sas-flash-vp'
     UNKNOWN = 'unknown'
 
-    ALL = (SATA, SAS, SSD, NL_SSD, UNKNOWN)
+    ALL = (
+        SATA, SAS, SSD, NL_SSD, FC, LUN, ATA, FLASH, VMDISK,
+        NL_SAS, SSD_CARD, SAS_FLASH_VP, UNKNOWN)
 
 
 class DiskLogicalType(object):
@@ -141,9 +151,22 @@ class DiskLogicalType(object):
     MEMBER = 'member'
     HOTSPARE = 'hotspare'
     CACHE = 'cache'
+    AGGREGATE = 'aggregate'
+    BROKEN = 'broken'
+    FOREIGN = 'foreign'
+    LABELMAINT = 'labelmaint'
+    MAINTENANCE = 'maintenance'
+    SHARED = 'shared'
+    SPARE = 'spare'
+    UNASSIGNED = 'unassigned'
+    UNSUPPORTED = 'unsupported'
+    REMOTE = 'remote'
+    MEDIATOR = 'mediator'
     UNKNOWN = 'unknown'
 
-    ALL = (FREE, MEMBER, HOTSPARE, CACHE, UNKNOWN)
+    ALL = (FREE, MEMBER, HOTSPARE, CACHE, AGGREGATE, BROKEN, FOREIGN,
+           LABELMAINT, MAINTENANCE, SHARED, SPARE, UNASSIGNED, UNSUPPORTED,
+           REMOTE, MEDIATOR, UNKNOWN)
 
 
 class FilesystemStatus(object):


### PR DESCRIPTION
What this PR does / why we need it:
Add  the physical type and logical type of the disk,in order to facilitate the matching of type data. such as Netapp devices have many logical  types.

Which issue this PR fixes(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged): fixes #580

Special notes for your reviewer:

Release note:

