### PR TITLE
fix the issue which codecoverage more than 70% but report error

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,5 +6,7 @@ coverage:
   precision: 2
   round: down
   status:
-    patch: false
-
+    project:
+      default:
+        target: 70%
+    patch: off


### PR DESCRIPTION
1.when codecoverage more than 70% but less than last PR,now it's successed;
![image](https://user-images.githubusercontent.com/79631193/120599669-62593600-c47a-11eb-8413-cc283781c77e.png)
![image](https://user-images.githubusercontent.com/79631193/120599704-6b4a0780-c47a-11eb-8929-89ef898b0d3f.png)
2.when codecoverage less than 70%,report failed;
![image](https://user-images.githubusercontent.com/79631193/120599778-81f05e80-c47a-11eb-9d31-acbc0b58551a.png)
![image](https://user-images.githubusercontent.com/79631193/120599797-861c7c00-c47a-11eb-94e3-4761ce9194b6.png)