### PR TITLE
Add the port type

### DIFF
--- a/delfin/common/constants.py
+++ b/delfin/common/constants.py
@@ -106,10 +106,11 @@ class PortType(object):
     COMBO = 'combo'
     CNA = 'cna'
     RCIP = 'rcip'
+    NFS_CIFS = 'nfs-cifs'
     OTHER = 'other'
 
     ALL = (FC, ISCSI, FICON, FCOE, ETH, SAS, IB, LOGIC,
-           CIFS, NFS, FCACHE, COMBO, CNA, RCIP, OTHER)
+           CIFS, NFS, FCACHE, COMBO, CNA, RCIP, NFS_CIFS, OTHER)
 
 
 class PortLogicalType(object):


### PR DESCRIPTION
What this PR does / why we need it:
Add a port type of the port, in order to facilitate the matching of type data.

Which issue this PR fixes(optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #591
Special notes for your reviewer:

Release note: