### PR TITLE
DB models for host mapping

### DIFF
--- a/delfin/db/sqlalchemy/models.py
+++ b/delfin/db/sqlalchemy/models.py
@@ -289,9 +289,9 @@ class FailedTask(BASE, DelfinBase):
     deleted = Column(Boolean, default=False)
 
 
-class StorageInitiator(BASE, DelfinBase):
-    """Represents the storage initiator attributes."""
-    __tablename__ = 'storage_initiators'
+class StorageHostInitiator(BASE, DelfinBase):
+    """Represents the storage host initiator attributes."""
+    __tablename__ = 'storage_host_initiators'
     id = Column(String(36), primary_key=True)
     storage_id = Column(String(36))
     name = Column(String(255))
@@ -299,7 +299,7 @@ class StorageInitiator(BASE, DelfinBase):
     wwn = Column(String(255))
     status = Column(String(255))
     native_storage_host_id = Column(String(255))
-    native_storage_initiator_id = Column(String(255))
+    native_storage_host_initiator_id = Column(String(255))
 
 
 class StorageHost(BASE, DelfinBase):
@@ -310,7 +310,7 @@ class StorageHost(BASE, DelfinBase):
     name = Column(String(255))
     description = Column(String(255))
     os_type = Column(String(255))
-    storage_initiators = Column(Text)
+    storage_host_initiators = Column(Text)
     ip_address = Column(String(255))
     status = Column(String(255))
     native_storage_host_id = Column(String(255))
@@ -360,7 +360,7 @@ class MaskingView(BASE, DelfinBase):
     native_volume_group_id = Column(String(255))
     native_port_group_id = Column(String(255))
     native_storage_host_id = Column(String(255))
-    storage_initiators = Column(Text)
+    storage_host_initiators = Column(Text)
     volumes = Column(Text)
     ports = Column(Text)
     native_masking_view_id = Column(String(255))

--- a/delfin/db/sqlalchemy/models.py
+++ b/delfin/db/sqlalchemy/models.py
@@ -23,7 +23,8 @@ SQLAlchemy models for Delfin  data.
 from oslo_config import cfg
 from oslo_db.sqlalchemy import models
 from oslo_db.sqlalchemy.types import JsonEncodedDict
-from sqlalchemy import Column, Integer, String, Boolean, BigInteger, DateTime
+from sqlalchemy import Column, Integer, String, Boolean, BigInteger, \
+    DateTime, Text
 from sqlalchemy.ext.declarative import declarative_base
 
 from delfin.common import constants
@@ -286,3 +287,115 @@ class FailedTask(BASE, DelfinBase):
     job_id = Column(String(36))
     deleted_at = Column(DateTime)
     deleted = Column(Boolean, default=False)
+
+
+class StorageInitiator(BASE, DelfinBase):
+    """Represents the storage initiator attributes."""
+    __tablename__ = 'storage_initiators'
+    id = Column(String(36), primary_key=True)
+    storage_id = Column(String(36))
+    name = Column(String(255))
+    description = Column(String(255))
+    wwn = Column(String(255))
+    status = Column(String(255))
+    native_storage_host_id = Column(String(255))
+    native_storage_initiator_id = Column(String(255))
+
+
+class StorageHost(BASE, DelfinBase):
+    """Represents the storage host attributes."""
+    __tablename__ = 'storage_hosts'
+    id = Column(String(36), primary_key=True)
+    storage_id = Column(String(36))
+    name = Column(String(255))
+    description = Column(String(255))
+    os_type = Column(String(255))
+    storage_initiators = Column(Text)
+    ip_address = Column(String(255))
+    status = Column(String(255))
+    native_storage_host_id = Column(String(255))
+
+
+class StorageHostGroup(BASE, DelfinBase):
+    """Represents the storage host group attributes."""
+    __tablename__ = 'storage_host_groups'
+    id = Column(String(36), primary_key=True)
+    storage_id = Column(String(36))
+    name = Column(String(255))
+    description = Column(String(255))
+    storage_hosts = Column(Text)
+    native_storage_host_group_id = Column(String(255))
+
+
+class PortGroup(BASE, DelfinBase):
+    """Represents the port group attributes."""
+    __tablename__ = 'port_groups'
+    id = Column(String(36), primary_key=True)
+    storage_id = Column(String(36))
+    name = Column(String(255))
+    description = Column(String(255))
+    ports = Column(Text)
+    native_port_group_id = Column(String(255))
+
+
+class VolumeGroup(BASE, DelfinBase):
+    """Represents the volume group attributes."""
+    __tablename__ = 'volume_groups'
+    id = Column(String(36), primary_key=True)
+    storage_id = Column(String(36))
+    name = Column(String(255))
+    description = Column(String(255))
+    volumes = Column(Text)
+    native_volume_group_id = Column(String(255))
+
+
+class MaskingView(BASE, DelfinBase):
+    """Represents the masking view attributes."""
+    __tablename__ = 'masking_views'
+    id = Column(String(36), primary_key=True)
+    storage_id = Column(String(36))
+    name = Column(String(255))
+    description = Column(String(255))
+    native_storage_host_group_id = Column(String(255))
+    native_volume_group_id = Column(String(255))
+    native_port_group_id = Column(String(255))
+    native_storage_host_id = Column(String(255))
+    storage_initiators = Column(Text)
+    volumes = Column(Text)
+    ports = Column(Text)
+    native_masking_view_id = Column(String(255))
+
+
+class StorageHostGrpStorageHostRelation(BASE, DelfinBase):
+    """Represents the storage host group and storage host relation
+    attributes.
+    """
+    __tablename__ = 'storage_host_group_storage_host_relations'
+    id = Column(String(36), primary_key=True)
+    storage_id = Column(String(36))
+    name = Column(String(255))
+    description = Column(String(255))
+    native_storage_host_group_id = Column(String(255))
+    native_storage_host_id = Column(String(255))
+
+
+class PortGrpPortRelation(BASE, DelfinBase):
+    """Represents port group and port relation attributes."""
+    __tablename__ = 'port_group_port_relations'
+    id = Column(String(36), primary_key=True)
+    storage_id = Column(String(36))
+    name = Column(String(255))
+    description = Column(String(255))
+    native_port_group_id = Column(String(255))
+    native_port_id = Column(String(255))
+
+
+class VolumeGrpVolumeRelation(BASE, DelfinBase):
+    """Represents the volume group and volume relation attributes."""
+    __tablename__ = 'volume_group_volume_relations'
+    id = Column(String(36), primary_key=True)
+    storage_id = Column(String(36))
+    name = Column(String(255))
+    description = Column(String(255))
+    native_volume_group_id = Column(String(255))
+    native_volume_id = Column(String(255))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds db models needed for host mapping feature

Below tables are newly added 
StorageInitiator
StorageHost
StorageHostGroup
PortGroup
VolumeGroup
MaskingView
StorageHostGrpStorageHostRelation
PortGrpPortRelation
VolumeGrpVolumeRelation

**Note :** Some of these tables contain array of items for which Text data type is used. Array items will be separated using delimiters

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
Test report:
![image](https://user-images.githubusercontent.com/30930862/121656688-5fcf8f80-cabd-11eb-8c5f-8844c9b61df7.png)
