### PR TITLE
Add misfire_grace_time to apscheduler

### DIFF
--- a/delfin/api/v1/storages.py
+++ b/delfin/api/v1/storages.py
@@ -37,15 +37,6 @@ from delfin.task_manager.tasks import telemetry as task_telemetry
 LOG = log.getLogger(__name__)
 CONF = cfg.CONF
 
-telemetry_opts = [
-    cfg.IntOpt('performance_collection_interval',
-               default=constants.TelemetryCollection
-               .DEF_PERFORMANCE_COLLECTION_INTERVAL,
-               help='default interval (in sec) for performance collection'),
-]
-
-CONF.register_opts(telemetry_opts, "telemetry")
-
 
 class StorageController(wsgi.Controller):
     def __init__(self):

--- a/delfin/common/config.py
+++ b/delfin/common/config.py
@@ -31,6 +31,8 @@ from oslo_log import log
 from oslo_middleware import cors
 from oslo_utils import netutils
 
+from delfin.common import constants
+
 LOG = log.getLogger(__name__)
 
 CONF = cfg.CONF
@@ -106,6 +108,15 @@ storage_driver_opts = [
 ]
 
 CONF.register_opts(storage_driver_opts, group='storage_driver')
+
+telemetry_opts = [
+    cfg.IntOpt('performance_collection_interval',
+               default=constants.TelemetryCollection
+               .DEF_PERFORMANCE_COLLECTION_INTERVAL,
+               help='default interval (in sec) for performance collection'),
+]
+
+CONF.register_opts(telemetry_opts, "telemetry")
 
 
 def set_middleware_defaults():

--- a/delfin/task_manager/scheduler/schedulers/telemetry/telemetry_job.py
+++ b/delfin/task_manager/scheduler/schedulers/telemetry/telemetry_job.py
@@ -15,6 +15,7 @@
 from datetime import datetime
 
 import six
+from oslo_config import cfg
 from oslo_log import log
 from oslo_utils import importutils
 from oslo_utils import uuidutils
@@ -25,6 +26,7 @@ from delfin.task_manager.scheduler import scheduler
 from delfin.task_manager.scheduler.schedulers.telemetry.failed_telemetry_job \
     import FailedTelemetryJob
 
+CONF = cfg.CONF
 LOG = log.getLogger(__name__)
 
 
@@ -77,7 +79,9 @@ class TelemetryJob(object):
                 instance = collection_class.get_instance(ctx, task_id)
                 self.scheduler.add_job(
                     instance, 'interval', seconds=task['interval'],
-                    next_run_time=next_collection_time, id=job_id)
+                    next_run_time=next_collection_time, id=job_id,
+                    misfire_grace_time=int(
+                        CONF.telemetry.performance_collection_interval / 2))
 
                 update_task_dict = {'job_id': job_id,
                                     'last_run_time': last_run_time}
@@ -96,4 +100,6 @@ class TelemetryJob(object):
             FailedTelemetryJob(ctx), 'interval',
             seconds=TelemetryCollection.FAILED_JOB_SCHEDULE_INTERVAL,
             next_run_time=datetime.now(),
-            id=periodic_scheduler_job_id)
+            id=periodic_scheduler_job_id,
+            misfire_grace_time=int(
+                CONF.telemetry.performance_collection_interval / 2))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Set `misfire_grace_time` to apscheduler to avoid task failed
The explanation of `misfire_grace_time` is:
```
    :var int misfire_grace_time: the time (in seconds) how much this job's execution is allowed to
        be late
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #603 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
