### PR TITLE
Enhancements to Prometheus exporter

### DIFF
--- a/delfin/api/schemas/storage_capabilities_schema.py
+++ b/delfin/api/schemas/storage_capabilities_schema.py
@@ -40,7 +40,7 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'requests': {
+                        'iops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
@@ -67,7 +67,7 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'readRequests': {
+                        'readIops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
@@ -76,7 +76,7 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'writeRequests': {
+                        'writeIops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
@@ -85,15 +85,7 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'memoryUsage': {
-                            'type': 'object',
-                            'properties': {
-                                'unit': {'type': 'string', 'enum': ["%"]},
-                                'description': {'type': 'string',
-                                                'minLength': 1,
-                                                'maxLength': 255}
-                            },
-                        },
+
                     },
                     'additionalProperties': False
                 },
@@ -118,7 +110,7 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'requests': {
+                        'iops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
@@ -145,7 +137,7 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'readRequests': {
+                        'readIops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
@@ -154,7 +146,7 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'writeRequests': {
+                        'writeIops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
@@ -187,28 +179,10 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'requests': {
+                        'iops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
-                                'description': {'type': 'string',
-                                                'minLength': 1,
-                                                'maxLength': 255}
-                            },
-                        },
-                        'readResponseTime': {
-                            'type': 'object',
-                            'properties': {
-                                'unit': {'type': 'string', 'enum': ["ms"]},
-                                'description': {'type': 'string',
-                                                'minLength': 1,
-                                                'maxLength': 255}
-                            },
-                        },
-                        'writeResponseTime': {
-                            'type': 'object',
-                            'properties': {
-                                'unit': {'type': 'string', 'enum': ["ms"]},
                                 'description': {'type': 'string',
                                                 'minLength': 1,
                                                 'maxLength': 255}
@@ -232,7 +206,7 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'readRequests': {
+                        'readIops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
@@ -241,7 +215,7 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'writeRequests': {
+                        'writeIops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
@@ -250,6 +224,61 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
+                        'cacheHitRatio': {
+                            'type': 'object',
+                            'properties': {
+                                'unit': {'type': 'string', 'enum': ["%"]},
+                                'description': {'type': 'string',
+                                                'minLength': 1,
+                                                'maxLength': 255}
+                            },
+                        },
+                        'readCacheHitRatio': {
+                            'type': 'object',
+                            'properties': {
+                                'unit': {'type': 'string', 'enum': ["%"]},
+                                'description': {'type': 'string',
+                                                'minLength': 1,
+                                                'maxLength': 255}
+                            },
+                        },
+                        'writeCacheHitRatio': {
+                            'type': 'object',
+                            'properties': {
+                                'unit': {'type': 'string', 'enum': ["%"]},
+                                'description': {'type': 'string',
+                                                'minLength': 1,
+                                                'maxLength': 255}
+                            },
+                        },
+                        'ioSize': {
+                            'type': 'object',
+                            'properties': {
+                                'unit': {'type': 'string', 'enum': ["KB"]},
+                                'description': {'type': 'string',
+                                                'minLength': 1,
+                                                'maxLength': 255}
+                            },
+                        },
+                        'readIoSize': {
+                            'type': 'object',
+                            'properties': {
+                                'unit': {'type': 'string', 'enum': ["KB"]},
+                                'description': {'type': 'string',
+                                                'minLength': 1,
+                                                'maxLength': 255}
+                            },
+                        },
+                        'writeIoSize': {
+                            'type': 'object',
+                            'properties': {
+                                'unit': {'type': 'string', 'enum': ["KB"]},
+                                'description': {'type': 'string',
+                                                'minLength': 1,
+                                                'maxLength': 255}
+                            },
+                        },
+
                     },
                     'additionalProperties': False
                 },
@@ -274,25 +303,7 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'readResponseTime': {
-                            'type': 'object',
-                            'properties': {
-                                'unit': {'type': 'string', 'enum': ["ms"]},
-                                'description': {'type': 'string',
-                                                'minLength': 1,
-                                                'maxLength': 255}
-                            },
-                        },
-                        'writeResponseTime': {
-                            'type': 'object',
-                            'properties': {
-                                'unit': {'type': 'string', 'enum': ["ms"]},
-                                'description': {'type': 'string',
-                                                'minLength': 1,
-                                                'maxLength': 255}
-                            },
-                        },
-                        'requests': {
+                        'iops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
@@ -319,7 +330,7 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'readRequests': {
+                        'readIops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
@@ -328,28 +339,10 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'writeRequests': {
+                        'writeIops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
-                                'description': {'type': 'string',
-                                                'minLength': 1,
-                                                'maxLength': 255}
-                            },
-                        },
-                        'cpuUsage': {
-                            'type': 'object',
-                            'properties': {
-                                'unit': {'type': 'string', 'enum': ["%"]},
-                                'description': {'type': 'string',
-                                                'minLength': 1,
-                                                'maxLength': 255}
-                            },
-                        },
-                        'memoryUsage': {
-                            'type': 'object',
-                            'properties': {
-                                'unit': {'type': 'string', 'enum': ["%"]},
                                 'description': {'type': 'string',
                                                 'minLength': 1,
                                                 'maxLength': 255}
@@ -379,25 +372,7 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'readResponseTime': {
-                            'type': 'object',
-                            'properties': {
-                                'unit': {'type': 'string', 'enum': ["ms"]},
-                                'description': {'type': 'string',
-                                                'minLength': 1,
-                                                'maxLength': 255}
-                            },
-                        },
-                        'writeResponseTime': {
-                            'type': 'object',
-                            'properties': {
-                                'unit': {'type': 'string', 'enum': ["ms"]},
-                                'description': {'type': 'string',
-                                                'minLength': 1,
-                                                'maxLength': 255}
-                            },
-                        },
-                        'requests': {
+                        'iops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
@@ -424,7 +399,7 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'readRequests': {
+                        'readIops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
@@ -433,7 +408,7 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'writeRequests': {
+                        'writeIops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
@@ -466,7 +441,7 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'requests': {
+                        'iops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
@@ -475,16 +450,7 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'serviceTime': {
-                            'type': 'object',
-                            'properties': {
-                                'unit': {'type': 'string', 'enum': ["ms"]},
-                                'description': {'type': 'string',
-                                                'minLength': 1,
-                                                'maxLength': 255}
-                            },
-                        },
-                        'readRequests': {
+                        'readIops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
@@ -493,10 +459,28 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
-                        'writeRequests': {
+                        'writeIops': {
                             'type': 'object',
                             'properties': {
                                 'unit': {'type': 'string', 'enum': ["IOPS"]},
+                                'description': {'type': 'string',
+                                                'minLength': 1,
+                                                'maxLength': 255}
+                            },
+                        },
+                        'readThroughput': {
+                            'type': 'object',
+                            'properties': {
+                                'unit': {'type': 'string', 'enum': ["MB/s"]},
+                                'description': {'type': 'string',
+                                                'minLength': 1,
+                                                'maxLength': 255}
+                            },
+                        },
+                        'writeThroughput': {
+                            'type': 'object',
+                            'properties': {
+                                'unit': {'type': 'string', 'enum': ["MB/s"]},
                                 'description': {'type': 'string',
                                                 'minLength': 1,
                                                 'maxLength': 255}

--- a/delfin/drivers/fake_storage/__init__.py
+++ b/delfin/drivers/fake_storage/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import copy
 import random
 import decorator
 import math
@@ -513,7 +513,7 @@ class FakeStorageDriver(driver.StorageDriver):
                 labels['unit'] = metric_list[key]['unit']
                 m = constants.metric_struct(name=key, labels=labels,
                                             values=fake_metrics[key])
-                resource_metrics.append(m)
+                resource_metrics.append(copy.deepcopy(m))
         return resource_metrics
 
     @wait_random(MIN_WAIT, MAX_WAIT)

--- a/delfin/exporter/prometheus/exporter_server.py
+++ b/delfin/exporter/prometheus/exporter_server.py
@@ -24,13 +24,13 @@ LOG = log.getLogger(__name__)
 app = Flask(__name__)
 
 grp = cfg.OptGroup('PROMETHEUS_EXPORTER')
-
+METRICS_CACHE_DIR = '/var/lib/delfin/metrics'
 prometheus_opts = [
     cfg.StrOpt('metric_server_ip', default='0.0.0.0',
                help='The exporter server host  ip'),
     cfg.IntOpt('metric_server_port', default=8195,
                help='The exporter server port'),
-    cfg.StrOpt('metrics_dir', default='/var/lib/delfin/metrics',
+    cfg.StrOpt('metrics_dir', default=METRICS_CACHE_DIR,
 
                help='The temp directory to keep incoming metrics'),
 ]

--- a/delfin/exporter/prometheus/exporter_server.py
+++ b/delfin/exporter/prometheus/exporter_server.py
@@ -41,6 +41,9 @@ cfg.CONF(sys.argv[1:])
 @app.route("/metrics", methods=['GET'])
 def getfile():
     try:
+        if not os.path.exists(cfg.CONF.PROMETHEUS_EXPORTER.metrics_dir):
+            LOG.error('No metrics cache folder exists')
+            return ''
         os.chdir(cfg.CONF.PROMETHEUS_EXPORTER.metrics_dir)
     except OSError as e:
         LOG.error('Error opening metrics folder')

--- a/delfin/exporter/prometheus/exporter_server.py
+++ b/delfin/exporter/prometheus/exporter_server.py
@@ -45,16 +45,14 @@ def getfile():
     except OSError as e:
         LOG.error('Error opening metrics folder')
         raise Exception(e)
-    file_list = []
-    for file in glob.glob("*.prom"):
-        file_list.append(file)
     data = ''
-    for file in file_list:
+    for file in glob.glob("*.prom"):
         file_name = cfg.CONF.PROMETHEUS_EXPORTER.metrics_dir + '/' + file
         with open(file_name, "r") as f:
             data += f.read()
             # Remove a metric file after reading it
             os.remove(file_name)
+
     return data
 
 

--- a/delfin/exporter/prometheus/prometheus.py
+++ b/delfin/exporter/prometheus/prometheus.py
@@ -34,7 +34,6 @@ prometheus_opts = [
 ]
 cfg.CONF.register_opts(prometheus_opts, group=grp)
 
-
 """"
 The metrics received from driver is should be in this format
 storage_metrics = [Metric(name='response_time',
@@ -89,8 +88,10 @@ class PrometheusExporter(object):
     def push_to_prometheus(self, storage_metrics):
         self.timestamp_offset_ms = self.set_timestamp_offset_from_utc_ms()
         time_stamp = str(datetime.datetime.now().timestamp())
-        temp_file_name = self.metrics_dir + '/' + time_stamp + ".prom.temp"
-        actual_file_name = self.metrics_dir + '/' + time_stamp + ".prom"
+        temp_file_name = os.path.join(self.metrics_dir,
+                                      time_stamp + ".prom.temp")
+        actual_file_name = os.path.join(self.metrics_dir,
+                                        time_stamp + ".prom")
         # make a temp  file with current timestamp
         with open(temp_file_name, "w") as f:
             for metric in storage_metrics:
@@ -103,19 +104,20 @@ class PrometheusExporter(object):
                 resource_type = labels.get('resource_type')
                 resource_id = labels.get('resource_id')
                 unit = labels.get('unit')
+                type = labels.get('type', 'RAW')
                 value_type = labels.get('value_type', 'gauge')
                 prom_labels = (
-                    "storage_id=\"%s\","
-                    "storage_name=\"%s\","
-                    "storage_sn=\"%s\","
-                    "resource_type=\"%s\","
-                    "resource_id=\"%s\","
-                    "type=\"%s\","
-                    "unit=\"%s\","
-                    "value_type=\"%s\"" %
-                    (storage_id, storage_name, storage_sn, resource_type,
-                        resource_id,
-                        'RAW', unit, value_type))
+                        "storage_id=\"%s\","
+                        "storage_name=\"%s\","
+                        "storage_sn=\"%s\","
+                        "resource_type=\"%s\","
+                        "resource_id=\"%s\","
+                        "type=\"%s\","
+                        "unit=\"%s\","
+                        "value_type=\"%s\"" %
+                        (storage_id, storage_name, storage_sn, resource_type,
+                         resource_id,
+                         type, unit, value_type))
                 name = labels.get('resource_type') + '_' + name
                 self._write_to_prometheus_format(f, name, labels, prom_labels,
                                                  values)

--- a/delfin/exporter/prometheus/prometheus.py
+++ b/delfin/exporter/prometheus/prometheus.py
@@ -54,7 +54,7 @@ storage_metrics = [Metric(name='response_time',
 class PrometheusExporter(object):
 
     def __init__(self):
-        self.timestamp_offset_ms = self.set_timestamp_offset_from_utc_ms()
+        self.timestamp_offset_ms = 0
         self.metrics_dir = cfg.CONF.PROMETHEUS_EXPORTER.metrics_dir
 
     def set_timestamp_offset_from_utc_ms(self):
@@ -86,6 +86,7 @@ class PrometheusExporter(object):
                                         value, timestamp))
 
     def push_to_prometheus(self, storage_metrics):
+        self.timestamp_offset_ms = self.set_timestamp_offset_from_utc_ms()
         time_stamp = str(datetime.datetime.now().timestamp())
         temp_file_name = self.metrics_dir + '/' + time_stamp + ".prom.temp"
         actual_file_name = self.metrics_dir + '/' + time_stamp + ".prom"

--- a/delfin/exporter/prometheus/prometheus.py
+++ b/delfin/exporter/prometheus/prometheus.py
@@ -22,9 +22,9 @@ from tzlocal import get_localzone
 LOG = log.getLogger(__name__)
 
 grp = cfg.OptGroup('PROMETHEUS_EXPORTER')
-
+METRICS_CACHE_DIR = '/var/lib/delfin/metrics'
 prometheus_opts = [
-    cfg.StrOpt('metrics_dir', default='/var/lib/delfin/metrics',
+    cfg.StrOpt('metrics_dir', default=METRICS_CACHE_DIR,
 
                help='The temp directory to keep incoming metrics'),
     cfg.StrOpt('timezone',
@@ -33,6 +33,7 @@ prometheus_opts = [
                ),
 ]
 cfg.CONF.register_opts(prometheus_opts, group=grp)
+
 
 """"
 The metrics received from driver is should be in this format

--- a/delfin/exporter/prometheus/prometheus.py
+++ b/delfin/exporter/prometheus/prometheus.py
@@ -14,6 +14,7 @@
 import datetime
 import os
 import pytz
+import six
 
 from oslo_config import cfg
 from oslo_log import log
@@ -63,7 +64,9 @@ class PrometheusExporter(object):
                 os.makedirs(directory)
             return True
         except Exception as e:
-            LOG.error('Error while creating metrics directory')
+            msg = six.text_type(e)
+            LOG.error("Error while creating metrics directory. Reason: %s",
+                      msg)
             return False
 
     def set_timestamp_offset_from_utc_ms(self):
@@ -115,20 +118,20 @@ class PrometheusExporter(object):
                 resource_type = labels.get('resource_type')
                 resource_id = labels.get('resource_id')
                 unit = labels.get('unit')
-                type = labels.get('type', 'RAW')
+                m_type = labels.get('type', 'RAW')
                 value_type = labels.get('value_type', 'gauge')
                 prom_labels = (
-                        "storage_id=\"%s\","
-                        "storage_name=\"%s\","
-                        "storage_sn=\"%s\","
-                        "resource_type=\"%s\","
-                        "resource_id=\"%s\","
-                        "type=\"%s\","
-                        "unit=\"%s\","
-                        "value_type=\"%s\"" %
-                        (storage_id, storage_name, storage_sn, resource_type,
-                         resource_id,
-                         type, unit, value_type))
+                    "storage_id=\"%s\","
+                    "storage_name=\"%s\","
+                    "storage_sn=\"%s\","
+                    "resource_type=\"%s\","
+                    "resource_id=\"%s\","
+                    "type=\"%s\","
+                    "unit=\"%s\","
+                    "value_type=\"%s\"" %
+                    (storage_id, storage_name, storage_sn, resource_type,
+                        resource_id,
+                        m_type, unit, value_type))
                 name = labels.get('resource_type') + '_' + name
                 self._write_to_prometheus_format(f, name, labels, prom_labels,
                                                  values)

--- a/delfin/exporter/prometheus/prometheus.py
+++ b/delfin/exporter/prometheus/prometheus.py
@@ -103,13 +103,17 @@ class PrometheusExporter(object):
                 unit = labels.get('unit')
                 value_type = labels.get('value_type', 'gauge')
                 prom_labels = (
-                        "storage_id=\"%s\",storage_name=\"%s\","
-                        "storage_sn=\"%s\","
-                        "resource_type=\"%s\",resource_id=\"%s\""
-                        "type=\"%s\",unit=\"%s\",value_type=\"%s\"" %
-                        (storage_id, storage_name, storage_sn, resource_type,
-                         resource_id,
-                         'RAW', unit, value_type))
+                    "storage_id=\"%s\","
+                    "storage_name=\"%s\","
+                    "storage_sn=\"%s\","
+                    "resource_type=\"%s\","
+                    "resource_id=\"%s\","
+                    "type=\"%s\","
+                    "unit=\"%s\","
+                    "value_type=\"%s\"" %
+                    (storage_id, storage_name, storage_sn, resource_type,
+                        resource_id,
+                        'RAW', unit, value_type))
                 name = labels.get('resource_type') + '_' + name
                 self._write_to_prometheus_format(f, name, labels, prom_labels,
                                                  values)

--- a/delfin/exporter/prometheus/prometheus.py
+++ b/delfin/exporter/prometheus/prometheus.py
@@ -11,19 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import datetime
+import os
+import pytz
 
 from oslo_config import cfg
+from oslo_log import log
+from tzlocal import get_localzone
+
+LOG = log.getLogger(__name__)
 
 grp = cfg.OptGroup('PROMETHEUS_EXPORTER')
 
 prometheus_opts = [
-    cfg.StrOpt('metrics_cache_file', default='/var/lib/delfin/delfin_exporter'
-                                             '.txt',
-               help='The temp cache file used for persisting metrics'),
+    cfg.StrOpt('metrics_dir', default='/var/lib/delfin/metrics',
+
+               help='The temp directory to keep incoming metrics'),
+    cfg.StrOpt('timezone',
+               default='local',
+               help='time zone of prometheus server '
+               ),
 ]
 cfg.CONF.register_opts(prometheus_opts, group=grp)
-
 
 """"
 The metrics received from driver is should be in this format
@@ -41,26 +50,47 @@ storage_metrics = [Metric(name='response_time',
      values={1600998817585: 20.264160223426305})]
 """
 
-unit_of_metric = {'response_time': 'ms', 'throughput': 'IOPS',
-                  'read_throughput': 'IOPS', 'write_throughput': 'IOPS',
-                  'bandwidth': 'MBps', 'read_bandwidth': 'MBps',
-                  'write_bandwidth': 'MBps'
-                  }
-
 
 class PrometheusExporter(object):
 
+    def __init__(self):
+        self.timestamp_offset_ms = self.set_timestamp_offset_from_utc_ms()
+        self.metrics_dir = cfg.CONF.PROMETHEUS_EXPORTER.metrics_dir
+
+    def set_timestamp_offset_from_utc_ms(self):
+        """Set timestamp offset from utc required for all metrics"""
+        try:
+            timez = get_localzone()
+            if cfg.CONF.PROMETHEUS_EXPORTER.timezone != 'local':
+                timez = pytz.timezone(cfg.CONF.PROMETHEUS_EXPORTER.timezone)
+            timez.utcoffset(datetime.datetime.now())
+            return int(timez.utcoffset(
+                datetime.datetime.now()).total_seconds() * 1000)
+        except Exception:
+            LOG.error('Error while setting timestamp'
+                      ' offset for prometheus exporter')
+            # return no offset in case of an error
+            return 0
+
     # Print metrics in Prometheus format.
-    def _write_to_prometheus_format(self, f, metric, labels, values):
-        f.write("# HELP storage_%s storage metric for %s\n" % (metric, metric))
-        f.write("# TYPE storage_%s gauge\n" % metric)
+    def _write_to_prometheus_format(self, f, metric,
+                                    labels, prom_labels, values):
+        f.write("# HELP %s  metric for resource %s and instance %s\n"
+                % (metric, labels.get('resource_type'),
+                   labels.get('resource_id')))
+        f.write("# TYPE %s gauge\n" % metric)
 
         for timestamp, value in values.items():
-            f.write("storage_%s{%s} %f %d\n" % (metric, labels,
-                                                value, timestamp))
+            timestamp += self.timestamp_offset_ms
+            f.write("%s{%s} %f %d\n" % (metric, prom_labels,
+                                        value, timestamp))
 
     def push_to_prometheus(self, storage_metrics):
-        with open(cfg.CONF.PROMETHEUS_EXPORTER.metrics_cache_file, "a+") as f:
+        time_stamp = str(datetime.datetime.now().timestamp())
+        temp_file_name = self.metrics_dir + '/' + time_stamp + ".prom.temp"
+        actual_file_name = self.metrics_dir + '/' + time_stamp + ".prom"
+        # make a temp  file with current timestamp
+        with open(temp_file_name, "w") as f:
             for metric in storage_metrics:
                 name = metric.name
                 labels = metric.labels
@@ -69,14 +99,23 @@ class PrometheusExporter(object):
                 storage_name = labels.get('name')
                 storage_sn = labels.get('serial_number')
                 resource_type = labels.get('resource_type')
-                unit = unit_of_metric.get(name)
+                resource_id = labels.get('resource_id')
+                unit = labels.get('unit')
                 value_type = labels.get('value_type', 'gauge')
-                storage_labels = (
-                    "storage_id=\"%s\",storage_name=\"%s\",storage_sn=\"%s\","
-                    "resource_type=\"%s\", "
-                    "type=\"%s\",unit=\"%s\",value_type=\"%s\"" %
-                    (storage_id, storage_name, storage_sn, resource_type,
-                     'RAW', unit, value_type))
-
-                self._write_to_prometheus_format(f, name, storage_labels,
+                prom_labels = (
+                        "storage_id=\"%s\",storage_name=\"%s\","
+                        "storage_sn=\"%s\","
+                        "resource_type=\"%s\",resource_id=\"%s\""
+                        "type=\"%s\",unit=\"%s\",value_type=\"%s\"" %
+                        (storage_id, storage_name, storage_sn, resource_type,
+                         resource_id,
+                         'RAW', unit, value_type))
+                name = labels.get('resource_type') + '_' + name
+                self._write_to_prometheus_format(f, name, labels, prom_labels,
                                                  values)
+        # this is done so that the exporter server never see an incomplete file
+        try:
+            f.close()
+            os.renames(temp_file_name, actual_file_name)
+        except Exception:
+            LOG.error('Error while renaming the temporary metric file')

--- a/delfin/exporter/prometheus/prometheus.py
+++ b/delfin/exporter/prometheus/prometheus.py
@@ -57,6 +57,15 @@ class PrometheusExporter(object):
         self.timestamp_offset_ms = 0
         self.metrics_dir = cfg.CONF.PROMETHEUS_EXPORTER.metrics_dir
 
+    def check_metrics_dir_exists(self, directory):
+        try:
+            if not os.path.exists(directory):
+                os.makedirs(directory)
+            return True
+        except Exception as e:
+            LOG.error('Error while creating metrics directory')
+            return False
+
     def set_timestamp_offset_from_utc_ms(self):
         """Set timestamp offset from utc required for all metrics"""
         try:
@@ -87,6 +96,8 @@ class PrometheusExporter(object):
 
     def push_to_prometheus(self, storage_metrics):
         self.timestamp_offset_ms = self.set_timestamp_offset_from_utc_ms()
+        if not self.check_metrics_dir_exists(self.metrics_dir):
+            return
         time_stamp = str(datetime.datetime.now().timestamp())
         temp_file_name = os.path.join(self.metrics_dir,
                                       time_stamp + ".prom.temp")

--- a/delfin/tests/unit/api/fakes.py
+++ b/delfin/tests/unit/api/fakes.py
@@ -439,7 +439,7 @@ def fake_get_capabilities(context, storage_id):
                         "description": "Average time taken for an IO "
                                        "operation in ms"
                     },
-                    "requests": {
+                    "iops": {
                         "unit": "IOPS",
                         "description": "Input/output operations per second"
                     },
@@ -453,15 +453,218 @@ def fake_get_capabilities(context, storage_id):
                         "description": "Represents how much data write is "
                                        "successfully transferred in MB/s"
                     },
-                    "readRequests": {
+                    "readIops": {
                         "unit": "IOPS",
                         "description": "Read requests per second"
                     },
-                    "writeRequests": {
+                    "writeIops": {
                         "unit": "IOPS",
                         "description": "Write requests per second"
                     },
-                }
+                },
+                "storagePool": {
+                    "throughput": {
+                        "unit": "MB/s",
+                        "description": "Total data transferred per second "
+                    },
+                    "responseTime": {
+                        "unit": "ms",
+                        "description": "Average time taken for an IO "
+                                       "operation"
+                    },
+                    "iops": {
+                        "unit": "IOPS",
+                        "description": "Read and write operations per second"
+                    },
+                    "readThroughput": {
+                        "unit": "MB/s",
+                        "description": "Total read data transferred per"
+                                       " second"
+                    },
+                    "writeThroughput": {
+                        "unit": "MB/s",
+                        "description": "Total write data transferred per"
+                                       " second "
+                    },
+                    "readIops": {
+                        "unit": "IOPS",
+                        "description": "Read operations per second"
+                    },
+                    "writeIops": {
+                        "unit": "IOPS",
+                        "description": "Write operations per second"
+                    },
+
+                },
+                "volume": {
+                    "throughput": {
+                        "unit": "MB/s",
+                        "description": "Total data transferred per second "
+                    },
+                    "responseTime": {
+                        "unit": "ms",
+                        "description": "Average time taken for an IO "
+                                       "operation"
+                    },
+                    "iops": {
+                        "unit": "IOPS",
+                        "description": "Read and write  operations per"
+                                       " second"
+                    },
+                    "readThroughput": {
+                        "unit": "MB/s",
+                        "description": "Total read data transferred per "
+                                       "second "
+                    },
+                    "writeThroughput": {
+                        "unit": "MB/s",
+                        "description": "Total write data transferred per"
+                                       " second "
+                    },
+                    "readIops": {
+                        "unit": "IOPS",
+                        "description": "Read operations per second"
+                    },
+                    "writeIops": {
+                        "unit": "IOPS",
+                        "description": "Write operations per second"
+                    },
+                    "cacheHitRatio": {
+                        "unit": "%",
+                        "description": "Percentage of io that are cache "
+                                       "hits"
+                    },
+                    "readCacheHitRatio": {
+                        "unit": "%",
+                        "description": "Percentage of read ops that are cache"
+                                       " hits"
+                    },
+                    "writeCacheHitRatio": {
+                        "unit": "%",
+                        "description": "Percentage of write ops that are cache"
+                                       " hits"
+                    },
+                    "ioSize": {
+                        "unit": "KB",
+                        "description": "The average size of IO requests in KB"
+                    },
+                    "readIoSize": {
+                        "unit": "KB",
+                        "description": "The average size of read IO requests "
+                                       "in KB."
+                    },
+                    "writeIoSize": {
+                        "unit": "KB",
+                        "description": "The average size of read IO requests"
+                                       " in KB."
+                    },
+                },
+                "controller": {
+                    "throughput": {
+                        "unit": "MB/s",
+                        "description": "Total data transferred per second "
+                    },
+                    "responseTime": {
+                        "unit": "ms",
+                        "description": "Average time taken for an IO "
+                                       "operation"
+                    },
+                    "iops": {
+                        "unit": "IOPS",
+                        "description": "Read and write  operations per "
+                                       "second"
+                    },
+                    "readThroughput": {
+                        "unit": "MB/s",
+                        "description": "Total read data transferred per "
+                                       "second "
+                    },
+                    "writeThroughput": {
+                        "unit": "MB/s",
+                        "description": "Total write data transferred per "
+                                       "second "
+                    },
+                    "readIops": {
+                        "unit": "IOPS",
+                        "description": "Read operations per second"
+                    },
+                    "writeIops": {
+                        "unit": "IOPS",
+                        "description": "Write operations per second"
+                    },
+
+                },
+                "port": {
+                    "throughput": {
+                        "unit": "MB/s",
+                        "description": "Total data transferred per second "
+                    },
+                    "responseTime": {
+                        "unit": "ms",
+                        "description": "Average time taken for an IO "
+                                       "operation"
+                    },
+                    "iops": {
+                        "unit": "IOPS",
+                        "description": "Read and write  operations per "
+                                       "second"
+                    },
+                    "readThroughput": {
+                        "unit": "MB/s",
+                        "description": "Total read data transferred per "
+                                       "second "
+                    },
+                    "writeThroughput": {
+                        "unit": "MB/s",
+                        "description": "Total write data transferred per "
+                                       "second "
+                    },
+                    "readIops": {
+                        "unit": "IOPS",
+                        "description": "Read operations per second"
+                    },
+                    "writeIops": {
+                        "unit": "IOPS",
+                        "description": "Write operations per second"
+                    },
+
+                },
+                "disk": {
+                    "throughput": {
+                        "unit": "MB/s",
+                        "description": "Total data transferred per second "
+                    },
+                    "responseTime": {
+                        "unit": "ms",
+                        "description": "Average time taken for an IO "
+                                       "operation"
+                    },
+                    "iops": {
+                        "unit": "IOPS",
+                        "description": "Read and write  operations per"
+                                       " second"
+                    },
+                    "readThroughput": {
+                        "unit": "MB/s",
+                        "description": "Total read data transferred per"
+                                       " second "
+                    },
+                    "writeThroughput": {
+                        "unit": "MB/s",
+                        "description": "Total write data transferred per"
+                                       " second "
+                    },
+                    "readIops": {
+                        "unit": "IOPS",
+                        "description": "Read operations per second"
+                    },
+                    "writeIops": {
+                        "unit": "IOPS",
+                        "description": "Write operations per second"
+                    },
+
+                },
+
             }
             }
 

--- a/delfin/tests/unit/drivers/test_api.py
+++ b/delfin/tests/unit/drivers/test_api.py
@@ -20,7 +20,7 @@ import sys
 
 from delfin import context
 from delfin import exception
-from delfin.common import config # noqa
+from delfin.common import config, constants  # noqa
 from delfin.drivers.api import API
 from delfin.drivers.fake_storage import FakeStorageDriver
 
@@ -74,7 +74,6 @@ class TestDriverAPI(TestCase):
     @mock.patch('delfin.db.storage_get_all')
     def test_discover_storage(self, mock_storage, mock_access_info,
                               mock_storage_create):
-
         # Case: Positive scenario for fake driver discovery
         storage = copy.deepcopy(STORAGE)
         storage['id'] = '12345'
@@ -350,3 +349,16 @@ class TestDriverAPI(TestCase):
 
         self.assertTrue('resource_metrics' in capabilities)
         driver_manager.assert_called_once()
+
+    @mock.patch('delfin.drivers.manager.DriverManager.get_driver')
+    def test_collect_perf_metrics(self, driver_manager):
+        driver_manager.return_value = FakeStorageDriver()
+        storage_id = '12345'
+        capabilities = API().get_capabilities(context, storage_id)
+
+        metrics = API().collect_perf_metrics(context, storage_id,
+                                             capabilities['resource_metrics'],
+                                             1622808000000, 1622808000001)
+        self.assertTrue('resource_metrics' in capabilities)
+        self.assertTrue(True, isinstance(metrics[0], constants.metric_struct))
+        self.assertEqual(driver_manager.call_count, 2)

--- a/delfin/tests/unit/exporter/prometheus/test_prometheus.py
+++ b/delfin/tests/unit/exporter/prometheus/test_prometheus.py
@@ -1,0 +1,35 @@
+# Copyright 2021 The SODA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import glob
+import os
+from unittest import TestCase
+
+from delfin.exporter.prometheus import prometheus
+from delfin.common.constants import metric_struct
+
+fake_metrics = [metric_struct(name='throughput',
+                              labels={'storage_id': '12345',
+                                      'resource_type': 'storage',
+                                      'resource_id': 'storage0',
+                                      'type': 'RAW', 'unit': 'MB/s'},
+                              values={1622808000000: 61.9388895680357})]
+
+
+class TestPrometheusExporter(TestCase):
+
+    def test_push_to_prometheus(self):
+        prometheus_obj = prometheus.PrometheusExporter()
+        prometheus_obj.metrics_dir = os.getcwd()
+        prometheus_obj.push_to_prometheus(fake_metrics)
+        self.assertTrue(glob.glob(prometheus_obj.metrics_dir + '/' + '*.prom'))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- [x] Support for new metrics
- [x] Fix for https://github.com/sodafoundation/delfin/issues/533
- [x] support for timestamp conversion based on prometheus server  timezone   
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #533

**Special notes for your reviewer**:
Change set from PR  #595 and #588 are included in this
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
**Test Report**
Prometheus graph displays all metrics for one port  with properties
{resource_type="port", resource_id="port0", storage_sn="6013136b-f5ee-4acf-9146-d20e927f090b" }
![Screenshot from 2021-06-15 20-05-36](https://user-images.githubusercontent.com/45681499/122075082-693b5d80-ce17-11eb-88b6-e74a52aa596a.png)
