### PR TITLE
Update containerized delfin exporter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,7 @@ services:
     volumes:
       - ./etc/delfin:/etc/delfin
       - db_data:/var/lib/delfin
+      - metrics_dir:${DELFIN_METRICS_DIR}
     restart: always
     environment:
       - OS_COORDINATION__BACKEND_SERVER=${DELFIN_HOST_IP}:6379
@@ -108,7 +109,7 @@ services:
     command: "exporter"
     volumes:
       - ./etc/delfin:/etc/delfin
-      - db_data:/var/lib/delfin
+      - metrics_dir:${DELFIN_METRICS_DIR}
     ports:
       - 8195:8195
     restart: always
@@ -119,3 +120,4 @@ services:
 
 volumes:
   db_data: {}
+  metrics_dir: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@
 #    $ export DELFIN_RABBITMQ_USER=delfinuser
 #    $ export DELFIN_RABBITMQ_PASS=delfinpass
 #    $ export DELFIN_HOST_IP=192.168.0.2
+#    $ export DELFIN_METRICS_DIR=/var/lib/delfin/metrics
 #
 # 3. Bring up delfin project using following command
 #
@@ -86,6 +87,7 @@ services:
     environment:
       - OS_COORDINATION__BACKEND_SERVER=${DELFIN_HOST_IP}:6379
       - OS_DEFAULT__TRANSPORT_URL=rabbit://${DELFIN_RABBITMQ_USER}:${DELFIN_RABBITMQ_PASS}@${DELFIN_HOST_IP}:5672//
+      - OS_PROMETHEUS_EXPORTER__METRICS_DIR=${DELFIN_METRICS_DIR}
     depends_on:
       - redis
       - rabbitmq
@@ -115,6 +117,7 @@ services:
     restart: always
     environment:
       - OS_DEFAULT__TRANSPORT_URL=rabbit://${DELFIN_RABBITMQ_USER}:${DELFIN_RABBITMQ_PASS}@${DELFIN_HOST_IP}:5672//
+      - OS_PROMETHEUS_EXPORTER__METRICS_DIR=${DELFIN_METRICS_DIR}
     depends_on:
       - rabbitmq
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,9 @@ services:
     command: "exporter"
     volumes:
       - ./etc/delfin:/etc/delfin
+      - db_data:/var/lib/delfin
+    ports:
+      - 8195:8195
     restart: always
     environment:
       - OS_DEFAULT__TRANSPORT_URL=rabbit://${DELFIN_RABBITMQ_USER}:${DELFIN_RABBITMQ_PASS}@${DELFIN_HOST_IP}:5672//


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Containeraized delfin deployment require, exporter to access metrics file and expose it to port 8195 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
