### PR TITLE
Add batch query interface of access infos and snmp configs

### DIFF
--- a/delfin/api/v1/access_info.py
+++ b/delfin/api/v1/access_info.py
@@ -48,6 +48,12 @@ class AccessInfoController(wsgi.Controller):
         access_info = self.driver_api.update_access_info(ctxt, access_info)
         return self._view_builder.show(access_info)
 
+    def show_all(self, req):
+        """Show all access information."""
+        ctxt = req.environ.get('delfin.context')
+        access_infos = db.access_info_get_all(ctxt)
+        return self._view_builder.show_all(access_infos)
+
 
 def create_resource():
     return wsgi.Resource(AccessInfoController())

--- a/delfin/api/v1/alert_source.py
+++ b/delfin/api/v1/alert_source.py
@@ -174,6 +174,13 @@ class AlertSourceController(wsgi.Controller):
 
         return alert_source
 
+    def show_all(self, req):
+        """Show all snmp configs."""
+        ctx = req.environ['delfin.context']
+        snmp_configs = db.alert_source_get_all(ctx)
+
+        return alert_view.show_all_snmp_configs(snmp_configs)
+
 
 def create_resource():
     return wsgi.Resource(AlertSourceController())

--- a/delfin/api/v1/alert_source.py
+++ b/delfin/api/v1/alert_source.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 from oslo_log import log
 from pyasn1.type.univ import OctetString
 
@@ -98,7 +99,7 @@ class AlertSourceController(wsgi.Controller):
                       "security_level are required."
                 raise exception.InvalidInput(msg)
 
-            if security_level == constants.SecurityLevel.AUTHNOPRIV\
+            if security_level == constants.SecurityLevel.AUTHNOPRIV \
                     or security_level == constants.SecurityLevel.AUTHPRIV:
                 auth_protocol = alert_source.get('auth_protocol')
                 auth_key = alert_source.get('auth_key')
@@ -176,10 +177,16 @@ class AlertSourceController(wsgi.Controller):
 
     def show_all(self, req):
         """Show all snmp configs."""
+        all_snmp_configs = []
         ctx = req.environ['delfin.context']
         snmp_configs = db.alert_source_get_all(ctx)
-
-        return alert_view.show_all_snmp_configs(snmp_configs)
+        for snmp_config in snmp_configs:
+            hosts = snmp_config['host'].split(',')
+            for host in hosts:
+                temp_snmp_config = copy.deepcopy(snmp_config)
+                temp_snmp_config['host'] = host
+                all_snmp_configs.append(temp_snmp_config)
+        return alert_view.show_all_snmp_configs(all_snmp_configs)
 
 
 def create_resource():

--- a/delfin/api/v1/alert_source.py
+++ b/delfin/api/v1/alert_source.py
@@ -177,16 +177,10 @@ class AlertSourceController(wsgi.Controller):
 
     def show_all(self, req):
         """Show all snmp configs."""
-        all_snmp_configs = []
         ctx = req.environ['delfin.context']
         snmp_configs = db.alert_source_get_all(ctx)
-        for snmp_config in snmp_configs:
-            hosts = snmp_config['host'].split(',')
-            for host in hosts:
-                temp_snmp_config = copy.deepcopy(snmp_config)
-                temp_snmp_config['host'] = host
-                all_snmp_configs.append(temp_snmp_config)
-        return alert_view.show_all_snmp_configs(all_snmp_configs)
+
+        return alert_view.show_all_snmp_configs(snmp_configs)
 
 
 def create_resource():

--- a/delfin/api/v1/alert_source.py
+++ b/delfin/api/v1/alert_source.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 from oslo_log import log
 from pyasn1.type.univ import OctetString
 
@@ -99,7 +98,7 @@ class AlertSourceController(wsgi.Controller):
                       "security_level are required."
                 raise exception.InvalidInput(msg)
 
-            if security_level == constants.SecurityLevel.AUTHNOPRIV \
+            if security_level == constants.SecurityLevel.AUTHNOPRIV\
                     or security_level == constants.SecurityLevel.AUTHPRIV:
                 auth_protocol = alert_source.get('auth_protocol')
                 auth_key = alert_source.get('auth_key')

--- a/delfin/api/v1/router.py
+++ b/delfin/api/v1/router.py
@@ -62,12 +62,17 @@ class APIRouter(common.APIRouter):
                        action="update",
                        conditions={"method": ["PUT"]})
 
+        mapper.connect("storages", "/access-infos",
+                       controller=self.resources['access_info'],
+                       action="show_all",
+                       conditions={"method": ["GET"]})
+
         self.resources['alert_sources'] = alert_source.create_resource()
-        mapper.connect("storages", "/storages/{id}/alert-source",
+        mapper.connect("storages", "/storages/{id}/snmp-config",
                        controller=self.resources['alert_sources'],
                        action="put",
                        conditions={"method": ["PUT"]})
-        mapper.connect("storages", "/storages/{id}/alert-source",
+        mapper.connect("storages", "/storages/{id}/snmp-config",
                        controller=self.resources['alert_sources'],
                        action="show",
                        conditions={"method": ["GET"]})
@@ -75,6 +80,10 @@ class APIRouter(common.APIRouter):
                        controller=self.resources['alert_sources'],
                        action="delete",
                        conditions={"method": ["DELETE"]})
+        mapper.connect("storages", "/snmp-configs",
+                       controller=self.resources['alert_sources'],
+                       action="show_all",
+                       conditions={"method": ["GET"]})
 
         self.resources['alerts'] = alerts.create_resource()
         mapper.connect("storages", "/storages/{id}/alerts/{sequence_number}",

--- a/delfin/api/v1/router.py
+++ b/delfin/api/v1/router.py
@@ -76,7 +76,7 @@ class APIRouter(common.APIRouter):
                        controller=self.resources['alert_sources'],
                        action="show",
                        conditions={"method": ["GET"]})
-        mapper.connect("storages", "/storages/{id}/alert-source",
+        mapper.connect("storages", "/storages/{id}/snmp-config",
                        controller=self.resources['alert_sources'],
                        action="delete",
                        conditions={"method": ["DELETE"]})

--- a/delfin/api/views/access_info.py
+++ b/delfin/api/views/access_info.py
@@ -23,3 +23,10 @@ class ViewBuilder(object):
             if access_info.get(access):
                 access_info[access].pop('password', None)
         return access_info_dict
+
+    def show_all(self, access_infos):
+        infos = []
+        for access_info in access_infos:
+            access_info_dict = self.show(access_info)
+            infos.append(access_info_dict)
+        return dict(access_infos=infos)

--- a/delfin/api/views/alert_source.py
+++ b/delfin/api/views/alert_source.py
@@ -33,3 +33,11 @@ def build_alert_source(value):
         # Remove the key not belong to snmpv3
         view.pop('community_string')
     return dict(view)
+
+
+def show_all_snmp_configs(values):
+    snmp_configs = []
+    for snmp_config in values:
+        snmp_config_dict = build_alert_source(dict(snmp_config))
+        snmp_configs.append(snmp_config_dict)
+    return dict(snmp_configs=snmp_configs)

--- a/delfin/tests/unit/api/fakes.py
+++ b/delfin/tests/unit/api/fakes.py
@@ -217,6 +217,26 @@ def fake_v3_alert_source():
     return alert_source
 
 
+def fake_all_snmp_configs():
+    alert_source = models.AlertSource()
+    alert_source.host = '127.0.0.1'
+    alert_source.storage_id = 'abcd-1234-5678'
+    alert_source.version = 'snmpv3'
+    alert_source.engine_id = '800000d30300000e112245'
+    alert_source.username = 'test1'
+    alert_source.auth_key = 'YWJjZDEyMzQ1Njc='
+    alert_source.auth_protocol = 'HMACMD5'
+    alert_source.privacy_key = 'YWJjZDEyMzQ1Njc='
+    alert_source.privacy_protocol = 'DES'
+    alert_source.port = 161
+    alert_source.context_name = ""
+    alert_source.retry_num = 1
+    alert_source.expiration = 1
+    alert_source.created_at = '2020-06-15T09:50:31.698956'
+    alert_source.updated_at = '2020-06-15T09:50:31.698956'
+    return [alert_source]
+
+
 def fake_v3_alert_source_noauth_nopriv():
     alert_source = models.AlertSource()
     alert_source.host = '127.0.0.1'
@@ -288,6 +308,25 @@ def fake_access_info_show(context, storage_id):
     access_info.extra_attributes = {'array_id': '0001234567897'}
 
     return access_info
+
+
+def fake_access_infos_show_all(context):
+    access_info = models.AccessInfo()
+
+    access_info.updated_at = '2020-06-15T09:50:31.698956'
+    access_info.storage_id = '865ffd4d-f1f7-47de-abc3-5541ef44d0c1'
+    access_info.created_at = '2020-06-15T09:50:31.698956'
+    access_info.vendor = 'fake_storage'
+    access_info.model = 'fake_driver'
+    access_info.rest = {
+        'host': '10.0.0.0',
+        'username': 'admin',
+        'password': 'YWJjZA==',
+        'port': 1234
+    }
+    access_info.extra_attributes = {'array_id': '0001234567897'}
+
+    return [access_info]
 
 
 def fake_update_access_info(self, context, access_info):
@@ -670,7 +709,6 @@ def fake_get_capabilities(context, storage_id):
 
 
 def custom_fake_get_capabilities(capabilities):
-
     def get_capability(context, storage_id):
         return capabilities
 

--- a/delfin/tests/unit/api/v1/test_access_info.py
+++ b/delfin/tests/unit/api/v1/test_access_info.py
@@ -110,3 +110,34 @@ class TestAccessInfoController(test.TestCase):
             "updated_at": "2020-06-15T09:50:31.698956"
         }
         self.assertDictEqual(expctd_dict, res_dict)
+
+    def test_show_all(self):
+        self.mock_object(
+            db, 'access_info_get_all',
+            fakes.fake_access_infos_show_all
+        )
+        req = fakes.HTTPRequest.blank('/storages/access-infos')
+
+        res_dict = self.controller.show_all(req)
+        expctd_dict = {
+            'access_infos': [{
+                "model": "fake_driver",
+                "vendor": "fake_storage",
+                "storage_id": "865ffd4d-f1f7-47de-abc3-5541ef44d0c1",
+                "rest": {
+                    "host": "10.0.0.0",
+                    "port": 1234,
+                    "username": "admin"
+                },
+                "ssh": None,
+                "cli": None,
+                "smis": None,
+                "extra_attributes": {
+                    "array_id": "0001234567897"
+                },
+                "created_at": "2020-06-15T09:50:31.698956",
+                "updated_at": "2020-06-15T09:50:31.698956"
+            }]
+        }
+
+        self.assertDictEqual(expctd_dict, res_dict)

--- a/delfin/tests/unit/api/v1/test_alert_source.py
+++ b/delfin/tests/unit/api/v1/test_alert_source.py
@@ -171,7 +171,7 @@ class AlertSourceControllerTestCase(unittest.TestCase):
     @mock.patch('delfin.db.alert_source_get')
     def test_delete_v3_config_success(self, mock_alert_source_get,
                                       mock_alert_source_delete):
-        req = fakes.HTTPRequest.blank('/storages/fake_id/alert-source')
+        req = fakes.HTTPRequest.blank('/storages/fake_id/snmp-config')
         fake_storage_id = 'abcd-1234-5678'
         mock_alert_source_delete.return_value = {}
         mock_alert_source_get.return_value = fakes.fake_v3_alert_source()
@@ -185,7 +185,7 @@ class AlertSourceControllerTestCase(unittest.TestCase):
     @mock.patch('delfin.db.alert_source_get',
                 fakes.alert_source_get_exception)
     def test_delete_v3_config_failure(self, mock_alert_source_delete):
-        req = fakes.HTTPRequest.blank('/storages/fake_id/alert-source')
+        req = fakes.HTTPRequest.blank('/storages/fake_id/snmp-config')
         fake_storage_id = 'abcd-1234-5678'
         mock_alert_source_delete.return_value = {}
 

--- a/delfin/tests/unit/api/v1/test_alert_source.py
+++ b/delfin/tests/unit/api/v1/test_alert_source.py
@@ -38,7 +38,7 @@ class AlertSourceControllerTestCase(unittest.TestCase):
     @mock.patch('delfin.db.alert_source_get')
     def test_put_v3_authpriv_config_create_success(self, mock_alert_source_get,
                                                    mock_alert_source_update):
-        req = fakes.HTTPRequest.blank('/storages/fake_id/alert-source')
+        req = fakes.HTTPRequest.blank('/storages/fake_id/snmp-config')
         fake_storage_id = 'abcd-1234-5678'
         expected_alert_source = {'storage_id': 'abcd-1234-5678',
                                  'host': '127.0.0.1',
@@ -72,7 +72,7 @@ class AlertSourceControllerTestCase(unittest.TestCase):
                                                        mock_alert_source_get,
                                                        mock_alert_source_update
                                                        ):
-        req = fakes.HTTPRequest.blank('/storages/fake_id/alert-source')
+        req = fakes.HTTPRequest.blank('/storages/fake_id/snmp-config')
         fake_storage_id = 'abcd-1234-5678'
         mock_alert_source_update.return_value = fakes. \
             fake_v3_alert_source_noauth_nopriv()
@@ -108,7 +108,7 @@ class AlertSourceControllerTestCase(unittest.TestCase):
     def test_put_v3_config_authnopriv_create_success(self,
                                                      mock_alert_source_get,
                                                      mock_alert_source_update):
-        req = fakes.HTTPRequest.blank('/storages/fake_id/alert-source')
+        req = fakes.HTTPRequest.blank('/storages/fake_id/snmp-config')
         fake_storage_id = 'abcd-1234-5678'
         mock_alert_source_update.return_value = fakes. \
             fake_v3_alert_source_auth_nopriv()
@@ -142,7 +142,7 @@ class AlertSourceControllerTestCase(unittest.TestCase):
     @mock.patch('delfin.db.alert_source_get')
     def test_put_v2_config_success(self, mock_alert_source_get,
                                    mock_alert_source_update):
-        req = fakes.HTTPRequest.blank('/storages/fake_id/alert-source')
+        req = fakes.HTTPRequest.blank('/storages/fake_id/snmp-config')
         fake_storage_id = 'abcd-1234-5678'
         return_v2_alert_source = fakes.fake_v2_alert_source()
         return_v2_alert_source['community_string'] = cryptor.encode(
@@ -201,7 +201,7 @@ class AlertSourceControllerTestCase(unittest.TestCase):
     @mock.patch('delfin.db.storage_get', mock.Mock())
     @mock.patch('delfin.db.alert_source_get')
     def test_show_v3_config(self, mock_alert_source_get):
-        req = fakes.HTTPRequest.blank('/storages/fake_id/alert-source')
+        req = fakes.HTTPRequest.blank('/storages/fake_id/snmp-config')
         fake_storage_id = 'abcd-1234-5678'
         mock_alert_source_get.return_value = fakes.fake_v3_alert_source()
         expected_alert_source = {'storage_id': 'abcd-1234-5678',
@@ -229,7 +229,7 @@ class AlertSourceControllerTestCase(unittest.TestCase):
     def test_put_v3_authpriv_no_priv_key(self,
                                          mock_alert_source_get,
                                          mock_alert_source_update):
-        req = fakes.HTTPRequest.blank('/storages/fake_id/alert-source')
+        req = fakes.HTTPRequest.blank('/storages/fake_id/snmp-config')
         fake_storage_id = 'abcd-1234-5678'
         mock_alert_source_update.return_value = {}
         mock_alert_source_get.return_value = fakes.fake_v3_alert_source()
@@ -251,7 +251,7 @@ class AlertSourceControllerTestCase(unittest.TestCase):
     def test_put_v3_authpriv_no_priv_protocol(self,
                                               mock_alert_source_get,
                                               mock_alert_source_update):
-        req = fakes.HTTPRequest.blank('/storages/fake_id/alert-source')
+        req = fakes.HTTPRequest.blank('/storages/fake_id/snmp-config')
         fake_storage_id = 'abcd-1234-5678'
         mock_alert_source_update.return_value = {}
         mock_alert_source_get.return_value = fakes.fake_v3_alert_source()
@@ -273,7 +273,7 @@ class AlertSourceControllerTestCase(unittest.TestCase):
     def test_put_v3_authnopriv_no_auth_protocol(self,
                                                 mock_alert_source_get,
                                                 mock_alert_source_update):
-        req = fakes.HTTPRequest.blank('/storages/fake_id/alert-source')
+        req = fakes.HTTPRequest.blank('/storages/fake_id/snmp-config')
         fake_storage_id = 'abcd-1234-5678'
         mock_alert_source_update.return_value = {}
         mock_alert_source_get.return_value = fakes.fake_v3_alert_source()
@@ -295,7 +295,7 @@ class AlertSourceControllerTestCase(unittest.TestCase):
     def test_put_v3_authnopriv_no_auth_key(self,
                                            mock_alert_source_get,
                                            mock_alert_source_update):
-        req = fakes.HTTPRequest.blank('/storages/fake_id/alert-source')
+        req = fakes.HTTPRequest.blank('/storages/fake_id/snmp-config')
         fake_storage_id = 'abcd-1234-5678'
         mock_alert_source_update.return_value = {}
         mock_alert_source_get.return_value = fakes.fake_v3_alert_source()
@@ -316,7 +316,7 @@ class AlertSourceControllerTestCase(unittest.TestCase):
     @mock.patch('delfin.db.alert_source_get')
     def test_put_without_username(self, mock_alert_source_get,
                                   mock_alert_source_update):
-        req = fakes.HTTPRequest.blank('/storages/fake_id/alert-source')
+        req = fakes.HTTPRequest.blank('/storages/fake_id/snmp-config')
         fake_storage_id = 'abcd-1234-5678'
         mock_alert_source_update.return_value = {}
         mock_alert_source_get.return_value = fakes.fake_v3_alert_source()
@@ -338,7 +338,7 @@ class AlertSourceControllerTestCase(unittest.TestCase):
     @mock.patch('delfin.db.alert_source_get')
     def test_put_without_engine_id(self, mock_alert_source_get,
                                    mock_alert_source_update):
-        req = fakes.HTTPRequest.blank('/storages/fake_id/alert-source')
+        req = fakes.HTTPRequest.blank('/storages/fake_id/snmp-config')
         fake_storage_id = 'abcd-1234-5678'
         mock_alert_source_update.return_value = {}
         mock_alert_source_get.return_value = fakes.fake_v3_alert_source()
@@ -360,7 +360,7 @@ class AlertSourceControllerTestCase(unittest.TestCase):
     @mock.patch('delfin.db.alert_source_get')
     def test_put_without_community_str(self, mock_alert_source_get,
                                        mock_alert_source_update):
-        req = fakes.HTTPRequest.blank('/storages/fake_id/alert-source')
+        req = fakes.HTTPRequest.blank('/storages/fake_id/snmp-config')
         fake_storage_id = 'abcd-1234-5678'
         mock_alert_source_update.return_value = {}
         mock_alert_source_get.return_value = fakes.fake_v2_alert_source()
@@ -385,7 +385,7 @@ class AlertSourceControllerTestCase(unittest.TestCase):
     def test_put_v3_snmp_validation_success(self,
                                             mock_alert_source_get,
                                             mock_alert_source_update):
-        req = fakes.HTTPRequest.blank('/storages/fake_id/alert-source')
+        req = fakes.HTTPRequest.blank('/storages/fake_id/snmp-config')
         fake_storage_id = 'abcd-1234-5678'
         mock_alert_source_update.return_value = fakes. \
             fake_v3_alert_source_auth_nopriv()
@@ -412,4 +412,29 @@ class AlertSourceControllerTestCase(unittest.TestCase):
 
         output_alert_source = alert_controller_inst.put(req, fake_storage_id,
                                                         body=body)
+        self.assertDictEqual(expected_alert_source, output_alert_source)
+
+    @mock.patch('delfin.db.alert_source_get_all')
+    def test_show_all_snmp_configs(self, mock_alert_source_get_all):
+        req = fakes.HTTPRequest.blank('/storages/snmp-configs')
+        mock_alert_source_get_all.return_value = fakes.fake_all_snmp_configs()
+        expected_alert_source = {
+            'snmp_configs': [{'storage_id': 'abcd-1234-5678',
+                              'host': '127.0.0.1',
+                              'version': 'snmpv3',
+                              'engine_id': '800000d30300000e112245',
+                              'security_level': None,
+                              'username': 'test1',
+                              'auth_protocol': 'HMACMD5',
+                              'privacy_protocol': 'DES',
+                              'port': 161,
+                              'context_name': "",
+                              'retry_num': 1,
+                              'expiration': 1,
+                              "created_at": '2020-06-15T09:50:31.698956',
+                              "updated_at": '2020-06-15T09:50:31.698956'
+                              }]
+        }
+        alert_controller_inst = self._get_alert_controller()
+        output_alert_source = alert_controller_inst.show_all(req)
         self.assertDictEqual(expected_alert_source, output_alert_source)

--- a/openapi-spec/swagger.yaml
+++ b/openapi-spec/swagger.yaml
@@ -431,7 +431,7 @@ paths:
     get:
       tags:
         - Storages
-      description: Get all access info of a registered storage backend
+      description: Get access info of all registered storages
       operationId: GetAllStorageAccessInfos
       responses:
         '200':

--- a/openapi-spec/swagger.yaml
+++ b/openapi-spec/swagger.yaml
@@ -3359,7 +3359,8 @@ components:
                 authPriv is set as security_level
             host:
               type: string
-              example: 10.0.0.1
+              description: All alert source ips of the device
+              example: 10.0.0.1,127.0.0.1
             context_name:
               type: string
               description: Context name of the alert source

--- a/openapi-spec/swagger.yaml
+++ b/openapi-spec/swagger.yaml
@@ -427,6 +427,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorSpec'
+  '/v1/storages/access-infos':
+    get:
+      tags:
+        - Storages
+      description: Get all access info of a registered storage backend
+      operationId: GetAllStorageAccessInfos
+      responses:
+        '200':
+          description: Storage Access-info  available
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageAccessInfosResponse'
+        '401':
+          description: NotAuthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSpec'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSpec'
+        '500':
+          description: An unexpected error occured.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSpec'
   /v1/storage-pools:
     get:
       tags:
@@ -1948,10 +1979,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorSpec'
-  '/v1/storages/{storage_id}/alert-source':
+  '/v1/storages/{storage_id}/snmp-config':
     get:
       tags:
-        - AlertSource
+        - SnmpConfig
       description: >-
         Get details snmp alert source information configured on behalf of
         backend devices
@@ -1970,7 +2001,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AlertSourceRespSpec'
+                $ref: '#/components/schemas/SnmpConfigRespSpec'
         '400':
           description: BadRequest
           content:
@@ -2003,11 +2034,11 @@ paths:
                 $ref: '#/components/schemas/ErrorSpec'
     put:
       tags:
-        - AlertSource
+        - SnmpConfig
       description: >-
         Modify snmp alert source information configured on behalf of backend
         devices
-      operationId: putAlertSourceInfo
+      operationId: putSnmpConfigInfo
       parameters:
         - name: storage_id
           in: path
@@ -2018,14 +2049,14 @@ paths:
           schema:
             type: string
       requestBody:
-        $ref: '#/components/requestBodies/AlertSourceUpdateSpec'
+        $ref: '#/components/requestBodies/SnmpConfigUpdateSpec'
       responses:
         '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AlertSourceRespSpec'
+                $ref: '#/components/schemas/SnmpConfigRespSpec'
         '400':
           description: BadRequest
           content:
@@ -2058,7 +2089,7 @@ paths:
                 $ref: '#/components/schemas/ErrorSpec'
     delete:
       tags:
-        - AlertSource
+        - SnmpConfig
       description: >-
         Removes snmp alert source information configured on behalf of backend
         devices
@@ -2247,6 +2278,44 @@ paths:
                 $ref: '#/components/schemas/ErrorSpec'
         '505':
           description: Capability feature not supported.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSpec'
+  '/v1/storages/snmp-configs':
+    get:
+      tags:
+        - Storages
+      description: >-
+        Get all details snmp alert source information configured on behalf of
+        backend devices
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SnmpConfigsRespSpec'
+        '400':
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSpec'
+        '401':
+          description: NotAuthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSpec'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorSpec'
+        '500':
+          description: An unexpected error occured.
           content:
             application/json:
               schema:
@@ -2643,6 +2712,15 @@ components:
             type: string
           example:
             array_id: string
+    StorageAccessInfosResponse:
+      description: Response for all access infos configuration.
+      type: object
+      properties:
+        snmp_configs:
+          type: array
+          description: the list of access info
+          items:
+            $ref: '#/components/schemas/StorageAccessInfoResponse'
 
 
     StoragePoolSpec:
@@ -3133,7 +3211,7 @@ components:
               type: string
             native_storage_pool_id:
               type: string
-    AlertSourceUpdateSpec:
+    SnmpConfigUpdateSpec:
       required:
         - host
         - version
@@ -3220,7 +3298,7 @@ components:
             By default, set to 161
           example: 20162
       description: SNMP alert source configuration attributes.
-    AlertSourceRespSpec:
+    SnmpConfigRespSpec:
       description: Response for snmp alert source configuration.
       allOf:
         - $ref: '#/components/schemas/BaseModel'
@@ -3304,6 +3382,15 @@ components:
                 Port for connecting to alert source
                 By default, set to 161
               example: 20162
+    SnmpConfigsRespSpec:
+      description: Response for all snmp alert source configuration.
+      type: object
+      properties:
+        snmp_configs:
+          type: array
+          description: the list of snmp configs
+          items:
+            $ref: '#/components/schemas/SnmpConfigRespSpec'
     StorageBackendAlertSync:
       type: object
       properties:
@@ -3491,11 +3578,11 @@ components:
       schema:
         type: string
   requestBodies:
-    AlertSourceUpdateSpec:
+    SnmpConfigUpdateSpec:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AlertSourceUpdateSpec'
+            $ref: '#/components/schemas/SnmpConfigUpdateSpec'
     StorageBackendAlertSync:
       content:
         application/json:


### PR DESCRIPTION
What this PR does / why we need it:
Add batch query interface of access infos and snmp configs.

Which issue this PR fixes(optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #617
Special notes for your reviewer:

Release note: