### PR TITLE
Use consistent resource name and serial number for fake driver across different collections

### DIFF
--- a/delfin/drivers/fake_storage/__init__.py
+++ b/delfin/drivers/fake_storage/__init__.py
@@ -124,11 +124,17 @@ class FakeStorageDriver(driver.StorageDriver):
     @wait_random(MIN_WAIT, MAX_WAIT)
     def get_storage(self, context):
         # Do something here
+
         sn = six.text_type(uuidutils.generate_uuid())
-        # get sn for already registered storage from DB
-        storage = db.storage_get(context, self.storage_id)
-        if storage:
-            sn = storage['serial_number']
+        try:
+            # use existing sn if already registered storage
+            storage = db.storage_get(context, self.storage_id)
+            if storage:
+                sn = storage['serial_number']
+        except exception.StorageNotFound:
+            LOG.debug('Registering new storage')
+        except Exception:
+            LOG.info('Error while retrieving storage from DB')
         total, used, free = self._get_random_capacity()
         raw = random.randint(2000, 3000)
         subscribed = random.randint(3000, 4000)

--- a/delfin/drivers/fake_storage/__init__.py
+++ b/delfin/drivers/fake_storage/__init__.py
@@ -509,7 +509,7 @@ class FakeStorageDriver(driver.StorageDriver):
         for i in range(resource_count):
             labels = {'storage_id': storage_id,
                       'resource_type': resource_type,
-                      'resource_id': resource_type + str(i),
+                      'resource_id': resource_type + '_' + str(i),
                       'type': 'RAW'}
             fake_metrics = self._get_random_performance(metric_list,
                                                         start_time, end_time)

--- a/delfin/tests/e2e/GetResources.robot
+++ b/delfin/tests/e2e/GetResources.robot
@@ -112,7 +112,7 @@ Get All Storages
 
 Open Application
     ${array_id}=            Register Test Storage
-    Sleep       1s
+    Sleep       5s
 
 Close Application
     @{storages}=            Get All Storages
@@ -120,4 +120,4 @@ Close Application
             ${storage_id}=  Get Value From Json	    ${storage} 	        $..id
             Delete Storage With ID                  ${storage_id[0]}
     END
-    Sleep       1s
+    Sleep       5s

--- a/delfin/tests/e2e/RegisterStorage.robot
+++ b/delfin/tests/e2e/RegisterStorage.robot
@@ -66,7 +66,7 @@ Register Storage with valid access_info Test
 
 Register Storage with same access_info Test
     [Tags]    DELFIN
-    Sleep                   1s
+    Sleep                   5s
     ${storage_test}=        Register Test Storage
 
     ${test}=                Load Json From File   ${CURDIR}/test.json

--- a/delfin/tests/e2e/RemoveStorage.robot
+++ b/delfin/tests/e2e/RemoveStorage.robot
@@ -12,7 +12,7 @@ ${delfin_url}           http://localhost:8190/v1
 
 Delete Storage with valid storage_id
     [Tags]    DELFIN
-    Sleep                   1s
+    Sleep                   5s
     ${storage_id_test}=     Register Test Storage
     Create Session          delfin      ${delfin_url}
     ${resp_del}=            DELETE On Session    delfin     storages/${storage_id_test}

--- a/delfin/tests/e2e/UpdateAccessInfo.robot
+++ b/delfin/tests/e2e/UpdateAccessInfo.robot
@@ -111,9 +111,9 @@ Close Application
             ${storage_id}=  Get Value From Json	    ${storage} 	        $..id
             Delete Storage With ID                  ${storage_id[0]}
     END
-    Sleep       1s
+    Sleep       5s
 
 Open Application
     ${array_id}=            Register Test Storage
-    Sleep       1s
+    Sleep       5s
 

--- a/delfin/tests/unit/drivers/test_api.py
+++ b/delfin/tests/unit/drivers/test_api.py
@@ -69,11 +69,12 @@ class TestDriverAPI(TestCase):
         api = API()
         self.assertIsNotNone(api.driver_manager)
 
+    @mock.patch('delfin.db.storage_get')
     @mock.patch('delfin.db.storage_create')
     @mock.patch('delfin.db.access_info_create')
     @mock.patch('delfin.db.storage_get_all')
     def test_discover_storage(self, mock_storage, mock_access_info,
-                              mock_storage_create):
+                              mock_storage_create, mock_get_storage):
         # Case: Positive scenario for fake driver discovery
         storage = copy.deepcopy(STORAGE)
         storage['id'] = '12345'
@@ -85,6 +86,7 @@ class TestDriverAPI(TestCase):
         mock_storage.assert_called()
         mock_access_info.assert_called_with(context, ACCESS_INFO)
         mock_storage_create.assert_called()
+        mock_get_storage.return_value = None
 
         # Case: Register already existing storage
         with self.assertRaises(exception.StorageAlreadyExists) as exc:
@@ -188,11 +190,12 @@ class TestDriverAPI(TestCase):
         msg = "Storage backend could not be found"
         self.assertIn(msg, str(exc.exception))
 
+    @mock.patch('delfin.db.storage_get')
     @mock.patch('delfin.db.storage_create')
     @mock.patch('delfin.db.access_info_create')
     @mock.patch('delfin.db.storage_get_all')
     def test_remove_storage(self, mock_storage, mock_access_info,
-                            mock_storage_create):
+                            mock_storage_create, mock_get_storage):
         storage = copy.deepcopy(STORAGE)
         storage['id'] = '12345'
         mock_storage.return_value = None
@@ -200,6 +203,7 @@ class TestDriverAPI(TestCase):
         mock_storage_create.return_value = storage
         api = API()
         api.discover_storage(context, ACCESS_INFO)
+        mock_get_storage.return_value = None
 
         storage_id = '12345'
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Use similar naming pattern for resource names in resource and perf metric collection 
Fix for #619 
increased E2E tests sleep time to 5sec to give some time for the DB to get updated before the next test run
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #619 

**Special notes for your reviewer**:
This is to help delfin clients to test with fake driver
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
