### PR TITLE
Add performance metrics collection support to VMAX drivers

### DIFF
--- a/delfin/drivers/dell_emc/vmax/constants.py
+++ b/delfin/drivers/dell_emc/vmax/constants.py
@@ -26,3 +26,144 @@ ARRAY_METRICS = ["HostIOs",
                  "WriteResponseTime"
                  ]
 VMAX_REST_TARGET_URI_ARRAY_PERF = '/performance/Array/metrics'
+
+VMAX_METRICS = [
+    'iops',
+    'readIops',
+    'writeIops',
+    'throughput',
+    'readThroughput',
+    'writeThroughput',
+    'responseTime'
+]
+
+BEDIRECTOR_METRICS = {
+    'iops': 'IOs',
+    'throughput': 'MBs',
+    'readThroughput': 'MBRead',
+    'writeThroughput': 'MBWritten',
+}
+FEDIRECTOR_METRICS = {
+    'iops': 'HostIOs',
+    'throughput': 'HostMBs',
+}
+RDFDIRECTOR_METRICS = {
+    'iops': 'IOs',
+    'throughput': 'MBSentAndReceived',
+    'readThroughput': 'MBRead',
+    'writeThroughput': 'MBWritten',
+    'responseTime': 'AverageIOServiceTime',
+}
+BEPORT_METRICS = {
+    'iops': 'IOs',
+    'throughput': 'MBs',
+    'readThroughput': 'MBRead',
+    'writeThroughput': 'MBWritten',
+}
+FEPORT_METRICS = {
+    'iops': 'IOs',
+    'throughput': 'MBs',
+    'readThroughput': 'MBRead',
+    'writeThroughput': 'MBWritten',
+    'responseTime': 'ResponseTime',
+}
+RDFPORT_METRICS = {
+    'iops': 'IOs',
+    'throughput': 'MBs',
+    'readThroughput': 'MBRead',
+    'writeThroughput': 'MBWritten',
+}
+POOL_METRICS = {
+    'iops': 'HostIOs',
+    'readIops': 'HostReads',
+    'writeIops': 'HostWrites',
+    'throughput': 'HostMBs',
+    'readThroughput': 'HostMBReads',
+    'writeThroughput': 'HostMBWritten',
+    'responseTime': 'ResponseTime',
+}
+STORAGE_METRICS = {
+    'iops': 'HostIOs',
+    'readIops': 'HostReads',
+    'writeIops': 'HostWrites',
+    'throughput': 'HostMBs',
+    'readThroughput': 'HostMBReads',
+    'writeThroughput': 'HostMBWritten',
+}
+
+IOPS_DESCRIPTION = {
+    "unit": "IOPS",
+    "description": "Input/output operations per second"
+}
+READ_IOPS_DESCRIPTION = {
+    "unit": "IOPS",
+    "description": "Read input/output operations per second"
+}
+WRITE_IOPS_DESCRIPTION = {
+    "unit": "IOPS",
+    "description": "Write input/output operations per second"
+}
+THROUGHPUT_DESCRIPTION = {
+    "unit": "MB/s",
+    "description": "Represents how much data is "
+                   "successfully transferred in MB/s"
+}
+READ_THROUGHPUT_DESCRIPTION = {
+    "unit": "MB/s",
+    "description": "Represents how much data read is "
+                   "successfully transferred in MB/s"
+}
+WRITE_THROUGHPUT_DESCRIPTION = {
+    "unit": "MB/s",
+    "description": "Represents how much data write is "
+                   "successfully transferred in MB/s"
+}
+RESPONSE_TIME_DESCRIPTION = {
+    "unit": "ms",
+    "description": "Average time taken for an IO "
+                   "operation in ms"
+}
+IO_SIZE_DESCRIPTION = {
+    "unit": "KB",
+    "description": "The average size of IO requests in KB"
+}
+READ_IO_SIZE_DESCRIPTION = {
+    "unit": "KB",
+    "description": "The average size of read IO requests in KB"
+}
+WRITE_IO_SIZE_DESCRIPTION = {
+    "unit": "KB",
+    "description": "The average size of write IO requests in KB"
+}
+STORAGE_CAP = {
+    "iops": IOPS_DESCRIPTION,
+    "readIops": READ_IOPS_DESCRIPTION,
+    "writeIops": WRITE_IOPS_DESCRIPTION,
+    "throughput": THROUGHPUT_DESCRIPTION,
+    "readThroughput": READ_THROUGHPUT_DESCRIPTION,
+    "writeThroughput": WRITE_THROUGHPUT_DESCRIPTION,
+    "responseTime": RESPONSE_TIME_DESCRIPTION,
+}
+POOL_CAP = {
+    "iops": IOPS_DESCRIPTION,
+    "readIops": READ_IOPS_DESCRIPTION,
+    "writeIops": WRITE_IOPS_DESCRIPTION,
+    "throughput": THROUGHPUT_DESCRIPTION,
+    "readThroughput": READ_THROUGHPUT_DESCRIPTION,
+    "writeThroughput": WRITE_THROUGHPUT_DESCRIPTION,
+    "responseTime": RESPONSE_TIME_DESCRIPTION,
+}
+CONTROLLER_CAP = {
+    "iops": IOPS_DESCRIPTION,
+    "throughput": THROUGHPUT_DESCRIPTION,
+    "readThroughput": READ_THROUGHPUT_DESCRIPTION,
+    "writeThroughput": WRITE_THROUGHPUT_DESCRIPTION,
+    "responseTime": RESPONSE_TIME_DESCRIPTION,
+}
+PORT_CAP = {
+    "iops": IOPS_DESCRIPTION,
+    "throughput": THROUGHPUT_DESCRIPTION,
+    "readThroughput": READ_THROUGHPUT_DESCRIPTION,
+    "writeThroughput": WRITE_THROUGHPUT_DESCRIPTION,
+    "responseTime": RESPONSE_TIME_DESCRIPTION,
+}

--- a/delfin/drivers/dell_emc/vmax/constants.py
+++ b/delfin/drivers/dell_emc/vmax/constants.py
@@ -17,26 +17,6 @@
 # minimum interval supported by VMAX
 VMAX_PERF_MIN_INTERVAL = 5
 
-ARRAY_METRICS = ["HostIOs",
-                 "HostMBWritten",
-                 "ReadResponseTime",
-                 "HostMBReads",
-                 "HostReads",
-                 "HostWrites",
-                 "WriteResponseTime"
-                 ]
-VMAX_REST_TARGET_URI_ARRAY_PERF = '/performance/Array/metrics'
-
-VMAX_METRICS = [
-    'iops',
-    'readIops',
-    'writeIops',
-    'throughput',
-    'readThroughput',
-    'writeThroughput',
-    'responseTime'
-]
-
 BEDIRECTOR_METRICS = {
     'iops': 'IOs',
     'throughput': 'MBs',

--- a/delfin/drivers/dell_emc/vmax/perf_utils.py
+++ b/delfin/drivers/dell_emc/vmax/perf_utils.py
@@ -65,6 +65,27 @@ def parse_performance_data(response):
     return metrics_map
 
 
+def construct_metrics(metrics_map, storage_id, perf):
+    metrics_list = []
+    for key in constants.VMAX_METRICS:
+        delfin_metrics = metrics_map.get(key)
+        if not delfin_metrics:
+            continue
+        labels = {
+            'storage_id': storage_id,
+            'resource_type': 'controller',
+            'resource_id': perf.get('resource_id'),
+            'resource_name': perf.get('resource_name'),
+            'type': 'RAW',
+            'unit': constants.CONTROLLER_CAP[key]['unit']
+        }
+        delfin_metrics = metrics_map[key]
+        metrics = constants.metric_struct(name=key, labels=labels,
+                                          values=delfin_metrics)
+        metrics_list.append(metrics)
+    return metrics_list
+
+
 def map_array_perf_metrics_to_delfin_metrics(metrics_value_map):
     """map vmax array performance metrics values  to delfin metrics values
         :param metrics_value_map: metric to values map of vmax metrics

--- a/delfin/drivers/dell_emc/vmax/rest.py
+++ b/delfin/drivers/dell_emc/vmax/rest.py
@@ -733,6 +733,24 @@ class VMaxRest(object):
             raise exception.StoragePerformanceCollectionFailed(message)
         return message
 
+    def get_pool_performance_metrics(self, pool_id, array, start_time, end_time):
+        """Get a array performance metrics from VMAX unipshere REST API.
+        :param array: the array serial number
+        :param start_time: start time for collection
+        :param end_time: end time for collection
+        :returns: message -- response from unipshere REST API
+         """
+
+        target_uri = constants.VMAX_REST_TARGET_URI_ARRAY_PERF
+        payload = perf_utils.generate_performance_payload(
+            array, start_time, end_time, constants.ARRAY_METRICS)
+        payload['srpId'] = pool_id
+        status_code, message = self.post_request(target_uri, payload)
+        # Expected 200 when POST request has metrics in response body
+        if status_code != STATUS_200:
+            raise exception.StoragePoolPerformanceCollectionFailed(message)
+        return message
+
     def list_pagination(self, list_info):
         """Process lists under or over the maxPageSize
         :param list_info: the object list information

--- a/delfin/drivers/dell_emc/vmax/vmax.py
+++ b/delfin/drivers/dell_emc/vmax/vmax.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import six
 from oslo_log import log
 
-from delfin import exception
 from delfin.common import constants
 from delfin.drivers import driver
 from delfin.drivers.dell_emc.vmax import client
@@ -137,20 +135,13 @@ class VMAXStorageDriver(driver.StorageDriver):
             if resource_metrics.get(constants.ResourceType.PORT):
                 port_metrics = self.client.get_port_metrics(
                     storage_id,
-                    resource_metrics.get(constants.ResourceType.PORT))
+                    resource_metrics.get(constants.ResourceType.PORT),
+                    start_time, end_time)
                 metrics.extend(port_metrics)
 
-        except exception.DelfinException as err:
-            err_msg = "Failed to collect metrics from VMAX: %s" %\
-                      (six.text_type(err))
-            LOG.error(err_msg)
-            raise err
-
-        except Exception as err:
-            err_msg = "Failed to collect metrics from VMAX: %s" %\
-                      (six.text_type(err))
-            LOG.error(err_msg)
-            raise exception.InvalidResults(err_msg)
+        except Exception:
+            LOG.error("Failed to collect metrics from VMAX")
+            raise
 
         return metrics
 
@@ -158,7 +149,7 @@ class VMAXStorageDriver(driver.StorageDriver):
     def get_capabilities(context):
         """Get capability of supported driver"""
         return {
-            'is_historic': False,
+            'is_historic': True,
             'resource_metrics': {
                 constants.ResourceType.STORAGE: consts.STORAGE_CAP,
                 constants.ResourceType.STORAGE_POOL: consts.POOL_CAP,

--- a/delfin/exporter/example.py
+++ b/delfin/exporter/example.py
@@ -20,9 +20,9 @@ LOG = log.getLogger(__name__)
 
 class AlertExporterExample(base_exporter.BaseExporter):
     def dispatch(self, ctxt, data):
-        LOG.info("AlertExporterExample, report data: %s" % data)
+        LOG.debug("AlertExporterExample, report data: %s" % data)
 
 
 class PerformanceExporterExample(base_exporter.BaseExporter):
     def dispatch(self, ctxt, data):
-        LOG.info("PerformanceExporterExample, report data: %s" % data)
+        LOG.debug("PerformanceExporterExample, report data: %s" % data)

--- a/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
+++ b/delfin/tests/unit/drivers/dell_emc/vmax/test_vmax.py
@@ -19,8 +19,7 @@ from requests.sessions import Session
 
 from delfin import context
 from delfin import exception
-from delfin.common import config  # noqa
-from delfin.common import constants
+from delfin.common import constants, config  # noqa
 from delfin.drivers.dell_emc.vmax.rest import VMaxRest
 from delfin.drivers.dell_emc.vmax.vmax import VMAXStorageDriver
 
@@ -569,271 +568,6 @@ class TestVMAXStorageDriver(TestCase):
         self.assertIn('Exception from Storage Backend:',
                       str(exc.exception))
 
-    @mock.patch.object(VMaxRest, 'post_request')
-    @mock.patch.object(VMaxRest, 'get_vmax_array_details')
-    @mock.patch.object(VMaxRest, 'get_array_detail')
-    @mock.patch.object(VMaxRest, 'get_uni_version')
-    @mock.patch.object(VMaxRest, 'get_unisphere_version')
-    def test_get_storage_performance(self, mock_unisphere_version,
-                                     mock_version, mock_array,
-                                     mock_array_details,
-                                     mock_performnace):
-        vmax_array_perf_resp_historic = {
-            "expirationTime": 1600172441701,
-            "count": 4321,
-            "maxPageSize": 1000,
-            "id": "d495891f-1607-42b7-ba8d-44d0786bd335_0",
-            "resultList": {
-                "result": [
-                    {
-                        "HostIOs": 296.1,
-                        "HostMBWritten": 0.31862956,
-                        "ReadResponseTime": 4.4177675,
-                        "HostMBReads": 0.05016927,
-                        "HostReads": 14.056666,
-                        "HostWrites": 25.78,
-                        "WriteResponseTime": 4.7228317,
-                        "timestamp": 1598875800000
-                    },
-                    {
-                        "HostIOs": 350.22998,
-                        "HostMBWritten": 0.40306965,
-                        "ReadResponseTime": 4.396796,
-                        "HostMBReads": 0.043291014,
-                        "HostReads": 13.213333,
-                        "HostWrites": 45.97333,
-                        "WriteResponseTime": 4.7806735,
-                        "timestamp": 1598876100000
-                    },
-                    {
-                        "HostIOs": 297.63333,
-                        "HostMBWritten": 0.25046548,
-                        "ReadResponseTime": 4.3915706,
-                        "HostMBReads": 0.042753905,
-                        "HostReads": 13.176666,
-                        "HostWrites": 28.643333,
-                        "WriteResponseTime": 4.8760557,
-                        "timestamp": 1598876400000
-                    }
-                ]
-            }
-        }
-        vmax_array_perf_resp_real_time = {
-            "expirationTime": 1600172441701,
-            "count": 4321,
-            "maxPageSize": 1000,
-            "id": "d495891f-1607-42b7-ba8d-44d0786bd335_0",
-            "resultList": {
-                "result": [
-                    {
-                        "HostIOs": 296.1,
-                        "HostMBWritten": 0.31862956,
-                        "ReadResponseTime": 4.4177675,
-                        "HostMBReads": 0.05016927,
-                        "HostReads": 14.056666,
-                        "HostWrites": 25.78,
-                        "WriteResponseTime": 4.7228317,
-                        "timestamp": 1598875800000
-                    }
-                ]
-            }
-        }
-
-        expected_historic = [
-            constants.metric_struct(name='responseTime',
-                                    labels={
-                                        'storage_id': '12345',
-                                        'resource_type':
-                                            'array'},
-                                    values={
-                                        1598875800000:
-                                            9.1405992,
-                                        1598876400000:
-                                            9.2676263,
-                                        1598876100000:
-                                            9.1774695}
-                                    ),
-            constants.metric_struct(name='throughput',
-                                    labels={
-                                        'storage_id': '12345',
-                                        'resource_type':
-                                            'array'},
-                                    values={
-                                        1598875800000:
-                                            0.36879882999999997,
-                                        1598876400000:
-                                            0.293219385,
-                                        1598876100000:
-                                            0.446360664}
-                                    ),
-            constants.metric_struct(name='readThroughput',
-                                    labels={
-                                        'storage_id': '12345',
-                                        'resource_type':
-                                            'array'},
-                                    values={
-                                        1598875800000:
-                                            0.05016927,
-                                        1598876100000:
-                                            0.043291014,
-                                        1598876400000:
-                                            0.042753905}
-                                    ),
-            constants.metric_struct(name='writeThroughput',
-                                    labels={
-                                        'storage_id': '12345',
-                                        'resource_type':
-                                            'array'},
-                                    values={
-                                        1598875800000:
-                                            0.31862956,
-                                        1598876100000:
-                                            0.40306965,
-                                        1598876400000:
-                                            0.25046548}
-                                    ),
-            constants.metric_struct(name='requests',
-                                    labels={
-                                        'storage_id': '12345',
-                                        'resource_type':
-                                            'array'},
-                                    values={
-                                        1598875800000: 296.1,
-                                        1598876100000:
-                                            350.22998,
-                                        1598876400000:
-                                            297.63333}
-                                    ),
-            constants.metric_struct(name='readRequests',
-                                    labels={
-                                        'storage_id': '12345',
-                                        'resource_type':
-                                            'array'},
-                                    values={
-                                        1598875800000:
-                                            14.056666,
-                                        1598876100000:
-                                            13.213333,
-                                        1598876400000:
-                                            13.176666}
-                                    ),
-            constants.metric_struct(name='writeRequests',
-                                    labels={
-                                        'storage_id': '12345',
-                                        'resource_type':
-                                            'array'},
-                                    values={
-                                        1598875800000: 25.78,
-                                        1598876100000:
-                                            45.97333,
-                                        1598876400000:
-                                            28.643333}
-                                    )
-        ]
-
-        expected_realtime = [
-            constants.metric_struct(name='responseTime',
-                                    labels={
-                                        'storage_id': '12345',
-                                        'resource_type':
-                                            'array'},
-                                    values={
-                                        1598875800000:
-                                            9.1405992
-                                    }
-                                    ),
-            constants.metric_struct(name='throughput',
-                                    labels={
-                                        'storage_id': '12345',
-                                        'resource_type':
-                                            'array'},
-                                    values={
-                                        1598875800000:
-                                            0.36879882999999997
-                                    }
-                                    ),
-            constants.metric_struct(name='readThroughput',
-                                    labels={
-                                        'storage_id': '12345',
-                                        'resource_type':
-                                            'array'},
-                                    values={
-                                        1598875800000:
-                                            0.05016927
-                                    }
-                                    ),
-            constants.metric_struct(name='writeThroughput',
-                                    labels={
-                                        'storage_id': '12345',
-                                        'resource_type': 'array'
-                                    },
-                                    values={
-                                        1598875800000: 0.31862956
-
-                                    }
-                                    ),
-            constants.metric_struct(name='requests',
-                                    labels={
-                                        'storage_id': '12345',
-                                        'resource_type':
-                                            'array'},
-                                    values={
-                                        1598875800000: 296.1
-                                    }
-                                    ),
-            constants.metric_struct(name='readRequests',
-                                    labels={
-                                        'storage_id': '12345',
-                                        'resource_type':
-                                            'array'},
-                                    values={
-                                        1598875800000:
-                                            14.056666
-                                    }
-                                    ),
-            constants.metric_struct(name='writeRequests',
-                                    labels={
-                                        'storage_id': '12345',
-                                        'resource_type':
-                                            'array'},
-                                    values={
-                                        1598875800000: 25.78
-                                    }
-                                    )
-        ]
-
-        kwargs = VMAX_STORAGE_CONF
-        mock_version.return_value = ['V9.0.2.7', '90']
-        mock_unisphere_version.return_value = ['V9.0.2.7', '90']
-        mock_array.return_value = {'symmetrixId': ['00112233']}
-        mock_array_details.return_value = {
-            'model': 'VMAX250F',
-            'ucode': '5978.221.221',
-            'display_name': 'VMAX250F-00112233'}
-        mock_performnace.return_value = 200, vmax_array_perf_resp_historic
-
-        driver = VMAXStorageDriver(**kwargs)
-        self.assertEqual(driver.storage_id, "12345")
-        self.assertEqual(driver.client.array_id, "00112233")
-
-        ret = driver.collect_perf_metrics(context, '12345', "", 10000000,
-                                          10900000)
-        self.assertEqual(ret, expected_historic)
-
-        mock_performnace.return_value = 200, vmax_array_perf_resp_real_time
-        ret = driver.collect_perf_metrics(context, '12345', "", 10900000,
-                                          10900000)
-        self.assertEqual(ret, expected_realtime)
-
-        mock_performnace.side_effect = \
-            exception.StoragePerformanceCollectionFailed
-        with self.assertRaises(Exception) as exc:
-            ret = driver.collect_perf_metrics(context, '12345', "", 10000000,
-                                              10900000)
-
-        self.assertIn('Failed to collect performance metrics. Reason',
-                      str(exc.exception))
-
     @mock.patch.object(Session, 'request')
     @mock.patch.object(VMaxRest, 'get_array_detail')
     @mock.patch.object(VMaxRest, 'get_uni_version')
@@ -879,5 +613,266 @@ class TestVMAXStorageDriver(TestCase):
         self.assertIsInstance(capabilities, dict)
         self.assertEqual(capabilities['is_historic'], True)
         self.assertIsInstance(capabilities['resource_metrics'], dict)
-        # Only support storage metrics
-        self.assertEqual(len(capabilities['resource_metrics']), 1)
+        # Support storage, storage_pool, controller and port metrics
+        self.assertEqual(len(capabilities['resource_metrics']), 4)
+
+    @mock.patch.object(VMaxRest, 'get_resource_metrics')
+    @mock.patch.object(VMaxRest, 'get_resource_keys')
+    @mock.patch.object(VMaxRest, 'get_array_keys')
+    @mock.patch.object(VMaxRest, 'get_array_detail')
+    @mock.patch.object(VMaxRest, 'get_uni_version')
+    @mock.patch.object(VMaxRest, 'get_unisphere_version')
+    def test_collect_perf_metrics(self, mock_unisphere_version,
+                                  mock_version,
+                                  mock_array, mock_array_keys,
+                                  mock_r_keys, mock_r_metrics):
+        expected = [
+            constants.metric_struct(name='iops',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type': 'storage',
+                                        'resource_id': '00112233',
+                                        'resource_name': 'VMAX00112233',
+                                        'type': 'RAW',
+                                        'unit': 'IOPS'},
+                                    values={1566550500000: 417.42667}
+                                    ),
+            constants.metric_struct(name='iops',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type': 'storagePool',
+                                        'resource_id': 'SRP_1',
+                                        'resource_name': 'SRP_1',
+                                        'type': 'RAW',
+                                        'unit': 'IOPS'},
+                                    values={1566550800000: 304.8}
+                                    ),
+            constants.metric_struct(name='iops',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type': 'controller',
+                                        'resource_id': 'DF-1C',
+                                        'resource_name': 'BEDirector_DF-1C',
+                                        'type': 'RAW',
+                                        'unit': 'IOPS'
+                                    },
+                                    values={1566987000000: 248.40666}
+                                    ),
+            constants.metric_struct(name='iops',
+                                    labels={
+                                        'storage_id': '12345',
+                                        'resource_type': 'port',
+                                        'resource_id': '12',
+                                        'resource_name': 'BEPort_DF-1C_12',
+                                        'type': 'RAW',
+                                        'unit': 'IOPS'
+                                    },
+                                    values={1566987000000: 6.693333}
+                                    ),
+        ]
+        kwargs = VMAX_STORAGE_CONF
+        mock_version.return_value = ['V9.0.2.7', '90']
+        mock_unisphere_version.return_value = ['V9.0.2.7', '90']
+        mock_array.return_value = {'symmetrixId': ['00112233']}
+
+        driver = VMAXStorageDriver(**kwargs)
+        self.assertEqual(driver.storage_id, "12345")
+        self.assertEqual(driver.client.array_id, "00112233")
+        ret_array_key = {
+            "arrayInfo": [{
+                "symmetrixId": "00112233",
+                "firstAvailableDate": "1566146400000",
+                "lastAvailableDate": "1566550800000",
+            }]
+        }
+        ret_pool_key = {
+            "srpInfo": [
+                {
+                    "srpId": "SRP_1",
+                    "firstAvailableDate": 1567065600000,
+                    "lastAvailableDate": 1568130900000
+                },
+            ]
+        }
+        ret_be_dir_key = {
+            "beDirectorInfo": [
+                {
+                    "directorId": "DF-1C",
+                    "firstAvailableDate": 1566557100000,
+                    "lastAvailableDate": 1566987300000
+                },
+            ]
+        }
+        ret_fe_dir_key = {
+            "feDirectorInfo": [
+                {
+                    "directorId": "FA-1D",
+                    "firstAvailableDate": 1567065600000,
+                    "lastAvailableDate": 1567093200000
+                },
+            ]
+        }
+        ret_rdf_dir_key = {
+            "rdfDirectorInfo": [
+                {
+                    "directorId": "RF-1F",
+                    "firstAvailableDate": 1567065600000,
+                    "lastAvailableDate": 1567437900000
+                },
+            ]
+        }
+        ret_be_port_key = {
+            "bePortInfo": [
+                {
+                    "portId": "12",
+                    "firstAvailableDate": 1566557100000,
+                    "lastAvailableDate": 1566988500000
+                },
+            ]
+        }
+        ret_fe_port_key = {
+            "fePortInfo": [
+                {
+                    "firstAvailableDate": 1567065600000,
+                    "lastAvailableDate": 1567162500000,
+                    "portId": "4"
+                },
+            ]
+        }
+        ret_rdf_port_key = {
+            "rdfPortInfo": [
+                {
+                    "portId": "7",
+                    "firstAvailableDate": 1567065600000,
+                    "lastAvailableDate": 1567439100000
+                }
+            ]
+        }
+        mock_array_keys.return_value = ret_array_key
+        mock_r_keys.side_effect = [
+            ret_pool_key,
+            ret_be_dir_key, ret_fe_dir_key, ret_rdf_dir_key,
+            ret_be_dir_key, ret_be_port_key,
+            ret_fe_dir_key, ret_fe_port_key,
+            ret_rdf_dir_key, ret_rdf_port_key,
+        ]
+        ret_array_metric = {
+            "HostIOs": 417.42667,
+            "HostMBs": 0.0018131511,
+            "FEReqs": 23.55,
+            "BEIOs": 25.216667,
+            "BEReqs": 5.55,
+            "PercentCacheWP": 0.031244868,
+            "timestamp": 1566550500000
+        }
+        ret_pool_metric = {
+            "HostIOs": 304.8,
+            "HostMBs": 0.005192057,
+            "FEReqs": 23.04,
+            "BEIOs": 22.566668,
+            "BEReqs": 4.7733335,
+            "PercentCacheWP": 0.018810686,
+            "timestamp": 1566550800000
+        }
+        ret_be_dir_metric = {
+            "PercentBusy": 0.025403459,
+            "IOs": 248.40666,
+            "Reqs": 3.91,
+            "MBRead": 1.7852213,
+            "MBWritten": 0.37213543,
+            "PercentNonIOBusy": 0.0,
+            "timestamp": 1566987000000
+        }
+        ret_fe_dir_metric = {
+            "PercentBusy": 2.54652,
+            "HostIOs": 3436.9368,
+            "HostMBs": 51.7072,
+            "Reqs": 3330.5947,
+            "ReadResponseTime": 0.12916493,
+            "WriteResponseTime": 0.3310084,
+            "timestamp": 1567078200000
+        }
+        ret_rdf_dir_metric = {
+            "PercentBusy": 4.8083158,
+            "IOs": 1474.2234,
+            "WriteReqs": 1189.76,
+            "MBWritten": 54.89597,
+            "MBRead": 0.4565983,
+            "MBSentAndReceived": 55.35257,
+            "AvgIOServiceTime": 0.89211756,
+            "CopyIOs": 0.0,
+            "CopyMBs": 0.0,
+            "timestamp": 1567161600000
+        }
+        ret_be_port_metric = {
+            "Reads": 4.7,
+            "Writes": 1.9933333,
+            "IOs": 6.693333,
+            "MBRead": 0.43401042,
+            "MBWritten": 0.10486979,
+            "MBs": 0.5388802,
+            "AvgIOSize": 82.44224,
+            "PercentBusy": 0.013356605,
+            "timestamp": 1566987000000
+        }
+        ret_fe_port_metric = {
+            "ResponseTime": 0.1263021,
+            "ReadResponseTime": 0.1263021,
+            "WriteResponseTime": 0.0,
+            "Reads": 0.32,
+            "Writes": 0.0,
+            "IOs": 0.32,
+            "MBRead": 4.296875E-4,
+            "MBWritten": 0.0,
+            "MBs": 4.296875E-4,
+            "AvgIOSize": 1.375,
+            "SpeedGBs": 16.0,
+            "PercentBusy": 2.6226044E-5,
+            "timestamp": 1567161600000
+        }
+        ret_rdf_port_metric = {
+            "Reads": 0.0,
+            "Writes": 1216.7633,
+            "IOs": 1216.7633,
+            "MBRead": 0.0,
+            "MBWritten": 57.559597,
+            "MBs": 57.559597,
+            "AvgIOSize": 48.440834,
+            "SpeedGBs": 16.0,
+            "PercentBusy": 3.5131588,
+            "timestamp": 1567161600000
+        }
+        mock_r_metrics.side_effect = [
+            [ret_array_metric],
+            [ret_pool_metric],
+            [ret_be_dir_metric],
+            [ret_fe_dir_metric],
+            [ret_rdf_dir_metric],
+            [ret_be_port_metric],
+            [ret_fe_port_metric],
+            [ret_rdf_port_metric],
+        ]
+        resource_metrics = {
+            'storage': {'iops': {'unit': 'IOPS'}},
+            'storagePool': {'iops': {'unit': 'IOPS'}},
+            'controller': {'iops': {'unit': 'IOPS'}},
+            'port': {'iops': {'unit': 'IOPS'}},
+        }
+        ret = driver.collect_perf_metrics(context,
+                                          driver.storage_id,
+                                          resource_metrics,
+                                          1000, 2000)
+
+        self.assertEqual(ret[0], expected[0])
+        self.assertEqual(ret[2], expected[1])
+        self.assertEqual(ret[4], expected[2])
+        self.assertEqual(ret[13], expected[3])
+
+        with self.assertRaises(Exception) as exc:
+            driver.collect_perf_metrics(context,
+                                        driver.storage_id,
+                                        resource_metrics,
+                                        1000, 2000
+                                        )
+
+        self.assertIn('', str(exc.exception))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add performance metrics collection support to VMAX drivers

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**NOT TESTED**

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
**Test Report**


**Log from task_manager with collected metrics:**
[task_manager.log](https://github.com/sodafoundation/delfin/files/6953263/task_manager.log)


**REST API calls from Delfin VMAX driver:**
[rest_api_calls.txt](https://github.com/sodafoundation/delfin/files/6952593/rest_api_calls.txt)

**Register storage Response:**
![Screenshot from 2021-08-09 12-33-32](https://user-images.githubusercontent.com/22949848/128670320-c56a894c-c5bc-4d4a-96f3-4ab2b823166f.png)
