### PR TITLE
Add a method to get device alert sources information

### DIFF
--- a/delfin/drivers/api.py
+++ b/delfin/drivers/api.py
@@ -162,3 +162,10 @@ class API(object):
         """Get capabilities from supported driver"""
         driver = self.driver_manager.get_driver(context, storage_id=storage_id)
         return driver.get_capabilities(context)
+
+    def get_alert_sources(self, context, storage_id):
+        access_info = db.access_info_get(context, storage_id)
+        driver = self.driver_manager.get_driver(context,
+                                                cache_on_load=False,
+                                                **access_info)
+        return driver.get_alert_sources(context)

--- a/delfin/drivers/driver.py
+++ b/delfin/drivers/driver.py
@@ -178,3 +178,6 @@ class StorageDriver(object):
     def get_capabilities(context):
         """Get capability of driver"""
         pass
+
+    def get_alert_sources(self, context):
+        return []


### PR DESCRIPTION
What this PR does / why we need it:
Add a method to get device alert sources information.

Which issue this PR fixes(optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #626
Special notes for your reviewer:

Release note: