### PR TITLE
[Issue-637] Fixing docker compose to bring delfin containers up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,11 +21,13 @@
 #
 #    $ docker build -t sodafoundation/delfin .
 #
-# 2. Export environment vars for IP addresses and rabbitmq credentials. Eg.
+# 2. Export (optional) environment vars for hostnames for redis, rabbitmq and credentials for rabbitmq. Eg.
+#    Here is example for exporting variable and its current values in setup.
 #
 #    $ export DELFIN_RABBITMQ_USER=delfinuser
 #    $ export DELFIN_RABBITMQ_PASS=delfinpass
-#    $ export DELFIN_HOST_IP=192.168.0.2
+#    $ export DELFIN_RABBITMQ_HOSTNAME=rabbitmq
+#    $ export DELFIN_REDIS_HOSTNAME=redis
 #    $ export DELFIN_METRICS_DIR=/var/lib/delfin/metrics
 #
 # 3. Bring up delfin project using following command
@@ -50,7 +52,7 @@ services:
 
   redis:
     image: redis
-    container_name: redis
+    container_name: ${DELFIN_REDIS_HOSTNAME:-redis}
     command: redis-server
     ports:
       - 6379:6379
@@ -58,10 +60,10 @@ services:
 
   rabbitmq:
       image: rabbitmq:3-management
-      container_name: rabbitmq
+      container_name: ${DELFIN_RABBITMQ_HOSTNAME:-rabbitmq}
       environment:
-          RABBITMQ_DEFAULT_USER: ${DELFIN_RABBITMQ_USER}
-          RABBITMQ_DEFAULT_PASS: ${DELFIN_RABBITMQ_PASS}
+          RABBITMQ_DEFAULT_USER: ${DELFIN_RABBITMQ_USER:-delfinuser}
+          RABBITMQ_DEFAULT_PASS: ${DELFIN_RABBITMQ_PASS:-delfinpass}
           RABBITMQ_DEFAULT_VHOST: "/"
       ports:
           - 5672:5672
@@ -78,8 +80,8 @@ services:
       - 8190:8190
     restart: always
     environment:
-      - OS_COORDINATION__BACKEND_SERVER=${DELFIN_HOST_IP}:6379
-      - OS_DEFAULT__TRANSPORT_URL=rabbit://${DELFIN_RABBITMQ_USER}:${DELFIN_RABBITMQ_PASS}@${DELFIN_HOST_IP}:5672//
+      - OS_COORDINATION__BACKEND_SERVER=${DELFIN_REDIS_HOSTNAME:-redis}:6379
+      - OS_DEFAULT__TRANSPORT_URL=rabbit://${DELFIN_RABBITMQ_USER:-delfinuser}:${DELFIN_RABBITMQ_PASS:-delfinpass}@${DELFIN_RABBITMQ_HOSTNAME:-rabbitmq}:5672//
     depends_on:
       - redis
       - rabbitmq
@@ -90,12 +92,12 @@ services:
     volumes:
       - ./etc/delfin:/etc/delfin
       - db_data:/var/lib/delfin
-      - metrics_dir:${DELFIN_METRICS_DIR}
+      - metrics_dir:${DELFIN_METRICS_DIR:-/var/lib/delfin/metrics}
     restart: always
     environment:
-      - OS_COORDINATION__BACKEND_SERVER=${DELFIN_HOST_IP}:6379
-      - OS_DEFAULT__TRANSPORT_URL=rabbit://${DELFIN_RABBITMQ_USER}:${DELFIN_RABBITMQ_PASS}@${DELFIN_HOST_IP}:5672//
-      - OS_PROMETHEUS_EXPORTER__METRICS_DIR=${DELFIN_METRICS_DIR}
+      - OS_COORDINATION__BACKEND_SERVER=${DELFIN_REDIS_HOSTNAME:-redis}:6379
+      - OS_DEFAULT__TRANSPORT_URL=rabbit://${DELFIN_RABBITMQ_USER:-delfinuser}:${DELFIN_RABBITMQ_PASS:-delfinpass}@${DELFIN_RABBITMQ_HOSTNAME:-rabbitmq}:5672//
+      - OS_PROMETHEUS_EXPORTER__METRICS_DIR=${DELFIN_METRICS_DIR:-/var/lib/delfin/metrics}
     depends_on:
       - redis
       - rabbitmq
@@ -108,8 +110,8 @@ services:
       - db_data:/var/lib/delfin
     restart: always
     environment:
-      - OS_COORDINATION__BACKEND_SERVER=${DELFIN_HOST_IP}:6379
-      - OS_DEFAULT__TRANSPORT_URL=rabbit://${DELFIN_RABBITMQ_USER}:${DELFIN_RABBITMQ_PASS}@${DELFIN_HOST_IP}:5672//
+      - OS_COORDINATION__BACKEND_SERVER=${DELFIN_REDIS_HOSTNAME:-redis}:6379
+      - OS_DEFAULT__TRANSPORT_URL=rabbit://${DELFIN_RABBITMQ_USER:-delfinuser}:${DELFIN_RABBITMQ_PASS:-delfinpass}@${DELFIN_RABBITMQ_HOSTNAME:-rabbitmq}:5672//
     depends_on:
       - redis
       - rabbitmq
@@ -119,13 +121,13 @@ services:
     command: "exporter"
     volumes:
       - ./etc/delfin:/etc/delfin
-      - metrics_dir:${DELFIN_METRICS_DIR}
+      - metrics_dir:${DELFIN_METRICS_DIR:-/var/lib/delfin/metrics}
     ports:
       - 8195:8195
     restart: always
     environment:
-      - OS_DEFAULT__TRANSPORT_URL=rabbit://${DELFIN_RABBITMQ_USER}:${DELFIN_RABBITMQ_PASS}@${DELFIN_HOST_IP}:5672//
-      - OS_PROMETHEUS_EXPORTER__METRICS_DIR=${DELFIN_METRICS_DIR}
+      - OS_DEFAULT__TRANSPORT_URL=rabbit://${DELFIN_RABBITMQ_USER:-delfinuser}:${DELFIN_RABBITMQ_PASS:-delfinpass}@${DELFIN_RABBITMQ_HOSTNAME:-rabbitmq}:5672//
+      - OS_PROMETHEUS_EXPORTER__METRICS_DIR=${DELFIN_METRICS_DIR:-/var/lib/delfin/metrics}
     depends_on:
       - rabbitmq
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR aimed to fix issue reported in https://github.com/sodafoundation/delfin/issues/637. 

Fix will cover :

1. Explicit setting up redis and rabbitmq hostname and referring the same in docker compose for all delfin container's env
2. Making a default values for redis, rabbimq host and credentials. User can only export those variable in case of specifying different values than default one. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
