### PR TITLE
Add the enum value of the controller status.

### DIFF
--- a/delfin/common/constants.py
+++ b/delfin/common/constants.py
@@ -51,9 +51,11 @@ class VolumeStatus(object):
 class ControllerStatus(object):
     NORMAL = 'normal'
     OFFLINE = 'offline'
+    FAULT = 'fault'
+    DEGRADED = 'degraded'
     UNKNOWN = 'unknown'
 
-    ALL = (NORMAL, OFFLINE, UNKNOWN)
+    ALL = (NORMAL, OFFLINE, FAULT, DEGRADED, UNKNOWN)
 
 
 class StorageType(object):


### PR DESCRIPTION
What this PR does / why we need it:
Add the enum value of the controller status.

Which issue this PR fixes(optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #649
Special notes for your reviewer:

Release note: