### PR TITLE
Remove db-scan for new task creation

### DIFF
--- a/delfin/task_manager/scheduler/schedule_manager.py
+++ b/delfin/task_manager/scheduler/schedule_manager.py
@@ -77,6 +77,9 @@ class SchedulerManager(object):
                 LOG.error("Failed to initialize periodic tasks, reason: %s.",
                           six.text_type(e))
                 raise e
+        # Recover the job in db
+        self.recover_job()
+        # Start the consumer of job creation message
         job_generator = service. \
             TaskService.create(binary='delfin-task',
                                topic='JobGenerator',
@@ -99,3 +102,7 @@ class SchedulerManager(object):
 
     def get_scheduler(self):
         return self.scheduler
+
+    def recover_job(self):
+        # TODO: would be implement when implement the consistent hashing
+        pass

--- a/delfin/tests/unit/leader_election/distributor/test_task_distributor.py
+++ b/delfin/tests/unit/leader_election/distributor/test_task_distributor.py
@@ -40,21 +40,6 @@ fake_telemetry_jobs = [
 
 class TestTaskDistributor(test.TestCase):
 
-    @mock.patch.object(db, 'task_get_all',
-                       mock.Mock(return_value=fake_telemetry_jobs))
-    @mock.patch.object(db, 'task_update',
-                       mock.Mock(return_value=fake_telemetry_job))
-    @mock.patch.object(db, 'task_get',
-                       mock.Mock(return_value=fake_telemetry_job))
-    @mock.patch(
-        'delfin.task_manager.metrics_rpcapi.TaskAPI.assign_job')
-    def test_telemetry_job_scheduling(self, mock_assign_job):
-        ctx = context.get_admin_context()
-        task_distributor = TaskDistributor(ctx)
-        # call telemetry job scheduling
-        task_distributor()
-        self.assertEqual(mock_assign_job.call_count, 1)
-
     @mock.patch.object(db, 'task_update')
     @mock.patch(
         'delfin.task_manager.metrics_rpcapi.TaskAPI.assign_job')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Remove the periodically call of scan new job

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

Use case:

1. When leader node up, all the job should be re-scan that whether it was needed to be assign again

Proposal:

1. When a node becomes a leader, in the `on_leading_callback` `schedule_boot_jobs`, call `recover_job` to recover the job in db

Test case:

1. When a node becomes a leader, the `recover_job` would be called
