### PR TITLE
Use consistent hash to manage the topic

### DIFF
--- a/delfin/task_manager/metrics_manager.py
+++ b/delfin/task_manager/metrics_manager.py
@@ -17,6 +17,7 @@ periodical task manager for metric collection tasks**
 from oslo_log import log
 
 from delfin import manager
+from delfin.coordination import ConsistentHashing
 from delfin.task_manager.scheduler import schedule_manager
 from delfin.task_manager.scheduler.schedulers.telemetry.job_handler \
     import FailedJobHandler
@@ -38,6 +39,9 @@ class MetricsTaskManager(manager.Manager):
         scheduler = schedule_manager.SchedulerManager()
         scheduler.start()
         JobHandler.schedule_boot_jobs()
+        partitioner = ConsistentHashing()
+        partitioner.start()
+        partitioner.join_group()
 
     def assign_job(self, context, task_id):
         instance = JobHandler.get_instance(context, task_id)

--- a/delfin/task_manager/scheduler/schedulers/telemetry/job_handler.py
+++ b/delfin/task_manager/scheduler/schedulers/telemetry/job_handler.py
@@ -129,8 +129,6 @@ class JobHandler(object):
             job = db.task_get(self.ctx, task_id)
             job_id = job['job_id']
             self.remove_scheduled_job(job_id)
-            db.task_delete(self.ctx, job['id'])
-            LOG.info("Removed job %s ", job['id'])
         except Exception as e:
             LOG.error("Failed to remove periodic scheduling job , reason: %s.",
                       six.text_type(e))

--- a/delfin/tests/unit/task_manager/scheduler/test_scheduler.py
+++ b/delfin/tests/unit/task_manager/scheduler/test_scheduler.py
@@ -12,10 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest import mock
+
 from apscheduler.schedulers.background import BackgroundScheduler
 
+from delfin import db
 from delfin import test
+from delfin.coordination import ConsistentHashing
+from delfin.leader_election.distributor.task_distributor \
+    import TaskDistributor
+from delfin.task_manager.metrics_rpcapi import TaskAPI
 from delfin.task_manager.scheduler import schedule_manager
+
+FAKE_TASKS = [
+    {
+        'id': 1,
+        'executor': 'node1'
+    },
+    {
+        'id': 2,
+        'executor': 'node2'
+    },
+    {
+        'id': 3,
+        'executor': 'node1'
+    }
+]
 
 
 class TestScheduler(test.TestCase):
@@ -28,3 +50,56 @@ class TestScheduler(test.TestCase):
         self.assertIsInstance(second_instance, BackgroundScheduler)
 
         self.assertEqual(first_instance, second_instance)
+
+    @mock.patch.object(BackgroundScheduler, 'start')
+    def test_start(self, mock_scheduler_start):
+        manager = schedule_manager.SchedulerManager()
+        manager.start()
+        self.assertEqual(mock_scheduler_start.call_count, 1)
+        manager.start()
+        self.assertEqual(mock_scheduler_start.call_count, 1)
+
+    @mock.patch('tooz.coordination.get_coordinator', mock.Mock())
+    @mock.patch.object(ConsistentHashing, 'get_task_executor')
+    @mock.patch.object(TaskAPI, 'remove_job')
+    @mock.patch.object(TaskDistributor, 'distribute_new_job')
+    @mock.patch.object(db, 'task_get_all')
+    def test_on_node_join(self, mock_task_get_all, mock_distribute_new_job,
+                          mock_remove_job, mock_get_task_executor):
+        node1_job_count = 0
+        node2_job_count = 0
+        for job in FAKE_TASKS:
+            if job['executor'] == 'node1':
+                node1_job_count += 1
+            elif job['executor'] == 'node2':
+                node2_job_count += 1
+        mock_task_get_all.return_value = FAKE_TASKS
+        mock_get_task_executor.return_value = 'node1'
+        manager = schedule_manager.SchedulerManager()
+        manager.on_node_join(mock.Mock(member_id=b'fake_member_id',
+                                       group_id='node1'))
+        self.assertEqual(mock_task_get_all.call_count, 1)
+        self.assertEqual(mock_distribute_new_job.call_count,
+                         node1_job_count + node2_job_count)
+        self.assertEqual(mock_remove_job.call_count, node2_job_count)
+        self.assertEqual(mock_get_task_executor.call_count,
+                         node1_job_count + node2_job_count)
+
+    @mock.patch.object(TaskDistributor, 'distribute_new_job')
+    @mock.patch.object(db, 'task_get_all')
+    def test_on_node_leave(self, mock_task_get_all, mock_distribute_new_job):
+        mock_task_get_all.return_value = FAKE_TASKS
+        manager = schedule_manager.SchedulerManager()
+        manager.on_node_leave(mock.Mock(member_id=b'fake_member_id',
+                                        group_id='fake_group_id'))
+        self.assertEqual(mock_task_get_all.call_count, 1)
+        self.assertEqual(mock_distribute_new_job.call_count, len(FAKE_TASKS))
+
+    @mock.patch.object(TaskDistributor, 'distribute_new_job')
+    @mock.patch.object(db, 'task_get_all')
+    def test_recover_job(self, mock_task_get_all, mock_distribute_new_job):
+        mock_task_get_all.return_value = FAKE_TASKS
+        manager = schedule_manager.SchedulerManager()
+        manager.recover_job()
+        self.assertEqual(mock_task_get_all.call_count, 1)
+        self.assertEqual(mock_distribute_new_job.call_count, len(FAKE_TASKS))

--- a/delfin/tests/unit/test_coordination.py
+++ b/delfin/tests/unit/test_coordination.py
@@ -118,3 +118,33 @@ class CoordinationTestCase(test.TestCase):
         bar.__getitem__.return_value = 8
         func(foo, bar)
         get_lock.assert_called_with('lock-func-7-8')
+
+
+class ConsistentHashingTestCase(test.TestCase):
+
+    def setUp(self):
+        super(ConsistentHashingTestCase, self).setUp()
+        self.get_coordinator = self.mock_object(tooz_coordination,
+                                                'get_coordinator')
+
+    def test_join_group(self):
+        crd = self.get_coordinator.return_value
+        part = coordination.ConsistentHashing()
+        part.start()
+        part.join_group()
+        self.assertTrue(crd.join_partitioned_group.called)
+
+    def test_register_watcher_func(self):
+        crd = self.get_coordinator.return_value
+        part = coordination.ConsistentHashing()
+        part.start()
+        part.register_watcher_func(mock.Mock(), mock.Mock())
+        self.assertTrue(crd.watch_join_group.called)
+        self.assertTrue(crd.watch_leave_group.called)
+
+    def test_watch_group_change(self):
+        crd = self.get_coordinator.return_value
+        part = coordination.ConsistentHashing()
+        part.start()
+        part.watch_group_change()
+        self.assertTrue(crd.run_watchers.called)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Use consistent hash to manage the topic of distributing job

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
Use case:

1. When metric task service launch, add it to partitioner group
2. Leader node would watch the group change periodically
   * If a new node was added to the group, re-scan all exist jobs, to check which executor they should have
     * If the new executor of a job is same as the old executor, do nothing
     * If the new executor is different with the old executor, remove the job from the old executor and add it to the new executor
   * If a exist node was removed from the group, get all the jobs whose executor is node which was down, and re-distribute that
3. When a distributor distribute a job, get executor from partitioner, and use it as the topic

Proposal:

1. When the `MetricsTaskManager` initialize, add it to the group
2. When a node becomes a leader, in the `on_leading_callback` `schedule_boot_jobs`, start a apscheduler to watch group change periodically
   * On `on_node_join`, re-scan all the exist jobs, and do different things according to whether the new executor is same as the old executor
   * On `on_node_leave`, re-distribute all the job whose executor is same as the node which is down
3. In `TaskDistributor.distribute_new_job`, get the executor from the group as topic of RabbitMQ, in order to distribute the job to specific node

Test case:

1. Every time a node up, a member would be added to the group 
2. Every time a node up, the watcher on leader node would get the event
3. When watched a node join event, re-scan all the jobs and re-distribute the specific job to the new node
4. Every time a node down, the member would be removed from the group
5. Every time a node down, the watcher on leader node would get the event
6. When watched a node leave event, re-distribute all the job whose executor is same as the node which is down
7. When distribute new job, the topic should be different when the task meta data is different

