### PR TITLE
 Start one historic collection immediate when a job is rescheduled

### DIFF
--- a/delfin/common/config.py
+++ b/delfin/common/config.py
@@ -114,6 +114,11 @@ telemetry_opts = [
                default=constants.TelemetryCollection
                .DEF_PERFORMANCE_COLLECTION_INTERVAL,
                help='default interval (in sec) for performance collection'),
+    cfg.IntOpt('performance_history_on_reschedule',
+               default=constants.TelemetryCollection
+               .DEF_PERFORMANCE_HISTORY_ON_RESCHEDULE,
+               help='default history(in sec) to be collected on a job '
+                    'reschedule'),
 ]
 
 CONF.register_opts(telemetry_opts, "telemetry")

--- a/delfin/common/constants.py
+++ b/delfin/common/constants.py
@@ -405,6 +405,7 @@ class TelemetryCollection(object):
     MAX_FAILED_JOB_RETRY_COUNT = 5
     """Default performance collection interval"""
     DEF_PERFORMANCE_COLLECTION_INTERVAL = 900
+    DEF_PERFORMANCE_HISTORY_ON_RESCHEDULE = 300
 
 
 class TelemetryTaskStatus(object):

--- a/delfin/task_manager/scheduler/schedulers/telemetry/job_handler.py
+++ b/delfin/task_manager/scheduler/schedulers/telemetry/job_handler.py
@@ -96,11 +96,19 @@ class JobHandler(object):
 
         if not (existing_job_id and scheduler_job):
             LOG.info('JobHandler scheduling a new job')
-            self.scheduler.add_job(
-                instance, 'interval', seconds=job['interval'],
-                next_run_time=next_collection_time, id=job_id,
-                misfire_grace_time=int(
-                    CONF.telemetry.performance_collection_interval / 2))
+            if job['last_run_time']:
+                # Start collection now if it is an old job
+                self.scheduler.add_job(
+                    instance, 'interval', seconds=job['interval'],
+                    next_run_time=datetime.now(), id=job_id,
+                    misfire_grace_time=int(
+                        CONF.telemetry.performance_collection_interval / 2))
+            else:
+                self.scheduler.add_job(
+                    instance, 'interval', seconds=job['interval'],
+                    next_run_time=next_collection_time, id=job_id,
+                    misfire_grace_time=int(
+                        CONF.telemetry.performance_collection_interval / 2))
 
             update_task_dict = {'job_id': job_id,
                                 'last_run_time': last_run_time}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When a job is rescheduled or when a node goes down and comes up momentarily. In order to make sure we do not lose  at least  one interval data schedule and immediate collect when the node receives a reschedule job or while booting.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #684 

**Special notes for your reviewer**:
Testing done.

- Register a new storage and make sure the next collection runs after the interval specified.
- Restart task process and make sure the existing job run immediate and collect one historic collection
- Run tasks on multiple node and bring down and bring up nodes. make sure every time when a redistribute happens existing job is run immediately .

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
