### PR TITLE
Change static method get_capabilities to member method.

### DIFF
--- a/delfin/drivers/dell_emc/vmax/vmax.py
+++ b/delfin/drivers/dell_emc/vmax/vmax.py
@@ -145,8 +145,7 @@ class VMAXStorageDriver(driver.StorageDriver):
 
         return metrics
 
-    @staticmethod
-    def get_capabilities(context):
+    def get_capabilities(self, context):
         """Get capability of supported driver"""
         return {
             'is_historic': True,

--- a/delfin/drivers/driver.py
+++ b/delfin/drivers/driver.py
@@ -174,8 +174,7 @@ class StorageDriver(object):
         raise NotImplementedError(
             "Driver API list_shares() is not Implemented")
 
-    @staticmethod
-    def get_capabilities(context):
+    def get_capabilities(self, context):
         """Get capability of driver"""
         pass
 

--- a/delfin/drivers/fake_storage/__init__.py
+++ b/delfin/drivers/fake_storage/__init__.py
@@ -558,8 +558,7 @@ class FakeStorageDriver(driver.StorageDriver):
             merged_metrics += m
         return merged_metrics
 
-    @staticmethod
-    def get_capabilities(context):
+    def get_capabilities(self, context):
         """Get capability of supported driver"""
         return {
             'is_historic': False,

--- a/delfin/drivers/huawei/oceanstor/oceanstor.py
+++ b/delfin/drivers/huawei/oceanstor/oceanstor.py
@@ -600,8 +600,7 @@ class OceanStorDriver(driver.StorageDriver):
 
         return metrics
 
-    @staticmethod
-    def get_capabilities(context):
+    def get_capabilities(self, context):
         """Get capability of supported driver"""
         return {
             'is_historic': False,

--- a/delfin/drivers/netapp/dataontap/cluster_mode.py
+++ b/delfin/drivers/netapp/dataontap/cluster_mode.py
@@ -86,6 +86,5 @@ class NetAppCmodeDriver(driver.StorageDriver):
         return self.netapp_handler.collect_perf_metrics(
             storage_id, resource_metrics, start_time, end_time)
 
-    @staticmethod
-    def get_capabilities(context):
+    def get_capabilities(self, context):
         return constant.PERF_CAPABILITIES

--- a/delfin/task_manager/tasks/telemetry.py
+++ b/delfin/task_manager/tasks/telemetry.py
@@ -18,6 +18,7 @@ import six
 from oslo_log import log
 
 from delfin import context, db
+from delfin import exception
 from delfin.common.constants import TelemetryTaskStatus
 from delfin.drivers import api as driver_api
 from delfin.exporter import base_exporter
@@ -57,6 +58,9 @@ class PerformanceCollectionTask(TelemetryTask):
                 for m in perf_metrics:
                     m.labels["name"] = storage_details.name
                     m.labels["serial_number"] = storage_details.serial_number
+            except exception.StorageNotFound:
+                LOG.warning(f'Storage(id={storage_id}) has been removed.')
+                return TelemetryTaskStatus.TASK_EXEC_STATUS_SUCCESS
             except Exception as e:
                 msg = _('Failed to add extra labels to performance '
                         'metrics: {0}'.format(e))

--- a/delfin/tests/e2e/testdriver/__init__.py
+++ b/delfin/tests/e2e/testdriver/__init__.py
@@ -224,8 +224,7 @@ class TestDriver(driver.StorageDriver):
 
         return array_metrics
 
-    @staticmethod
-    def get_capabilities(context):
+    def get_capabilities(self, context):
         """Get capability of supported driver"""
         return {
             'is_historic': False,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Storage devices may have different capabilities in different versions or different device type, static method can't  get more info of storage device.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
