### PR TITLE
 Improving Failed job handling and telemetry job removal

### DIFF
--- a/delfin/api/v1/storages.py
+++ b/delfin/api/v1/storages.py
@@ -33,7 +33,6 @@ from delfin.i18n import _
 from delfin.task_manager import perf_job_controller
 from delfin.task_manager import rpcapi as task_rpcapi
 from delfin.task_manager.tasks import resources
-from delfin.task_manager.tasks import telemetry as task_telemetry
 
 LOG = log.getLogger(__name__)
 CONF = cfg.CONF

--- a/delfin/api/v1/storages.py
+++ b/delfin/api/v1/storages.py
@@ -135,12 +135,6 @@ class StorageController(wsgi.Controller):
                 storage['id'],
                 subclass.__module__ + '.' + subclass.__name__)
 
-        for subclass in task_telemetry.TelemetryTask.__subclasses__():
-            self.task_rpcapi.remove_telemetry_instances(ctxt,
-                                                        storage['id'],
-                                                        subclass.__module__ +
-                                                        '.'
-                                                        + subclass.__name__)
         self.task_rpcapi.remove_storage_in_cache(ctxt, storage['id'])
         perf_job_controller.delete_perf_job(ctxt, storage['id'])
 

--- a/delfin/leader_election/distributor/task_distributor.py
+++ b/delfin/leader_election/distributor/task_distributor.py
@@ -44,6 +44,19 @@ class TaskDistributor(object):
                       six.text_type(e))
             raise e
 
+    def distribute_failed_job(self, failed_task_id, executor):
+
+        try:
+            db.failed_task_update(self.ctx, failed_task_id,
+                                  {'executor': executor})
+            LOG.info('Distribute a failed job, id: %s' % failed_task_id)
+            self.task_rpcapi.assign_failed_job(self.ctx, failed_task_id,
+                                               executor)
+        except Exception as e:
+            LOG.error('Failed to distribute failed job, reason: %s',
+                      six.text_type(e))
+            raise e
+
     @classmethod
     def job_interval(cls):
         return TelemetryCollection.PERIODIC_JOB_INTERVAL

--- a/delfin/task_manager/manager.py
+++ b/delfin/task_manager/manager.py
@@ -54,14 +54,6 @@ class TaskManager(manager.Manager):
         drivers = driver_manager.DriverManager()
         drivers.remove_driver(storage_id)
 
-    def remove_telemetry_instances(self, context, storage_id, telemetry_task):
-        LOG.info('Remove telemetry instances for storage id:{0}')
-        cls = importutils.import_class(telemetry_task)
-        device_obj = cls()
-        return device_obj.remove_telemetry(context,
-                                           storage_id,
-                                           )
-
     def sync_storage_alerts(self, context, storage_id, query_para):
         LOG.info('Alert sync called for storage id:{0}'
                  .format(storage_id))

--- a/delfin/task_manager/perf_job_controller.py
+++ b/delfin/task_manager/perf_job_controller.py
@@ -53,8 +53,15 @@ def delete_perf_job(context, storage_id):
     # Delete it from scheduler
     filters = {'storage_id': storage_id}
     tasks = db.task_get_all(context, filters=filters)
+    failed_tasks = db.failed_task_get_all(context, filters=filters)
     for task in tasks:
         metrics_rpcapi.TaskAPI().remove_job(context, task.get('id'),
                                             task.get('executor'))
-    # Delete it from db
+    for failed_task in failed_tasks:
+        metrics_rpcapi.TaskAPI().remove_failed_job(context,
+                                                   failed_task.get('id'),
+                                                   failed_task.get('executor'))
+
+    # Soft delete tasks
     db.task_delete_by_storage(context, storage_id)
+    db.failed_task_delete_by_storage(context, storage_id)

--- a/delfin/task_manager/scheduler/schedulers/telemetry/failed_performance_collection_handler.py
+++ b/delfin/task_manager/scheduler/schedulers/telemetry/failed_performance_collection_handler.py
@@ -22,9 +22,9 @@ from delfin.common.constants import TelemetryJobStatus, TelemetryCollection
 from delfin.db.sqlalchemy.models import FailedTask
 from delfin.db.sqlalchemy.models import Task
 from delfin.i18n import _
-from delfin.task_manager import rpcapi as task_rpcapi
 from delfin.task_manager.scheduler import schedule_manager
 from delfin.task_manager.tasks.telemetry import PerformanceCollectionTask
+from delfin.task_manager import metrics_rpcapi as metrics_task_rpcapi
 
 LOG = log.getLogger(__name__)
 CONF = cfg.CONF
@@ -32,7 +32,7 @@ CONF = cfg.CONF
 
 class FailedPerformanceCollectionHandler(object):
     def __init__(self, ctx, failed_task_id, storage_id, args, job_id,
-                 retry_count, start_time, end_time):
+                 retry_count, start_time, end_time, executor):
         self.ctx = ctx
         self.failed_task_id = failed_task_id
         self.retry_count = retry_count
@@ -41,10 +41,11 @@ class FailedPerformanceCollectionHandler(object):
         self.args = args
         self.start_time = start_time
         self.end_time = end_time
-        self.task_rpcapi = task_rpcapi.TaskAPI()
+        self.metrics_task_rpcapi = metrics_task_rpcapi.TaskAPI()
         self.scheduler_instance = \
             schedule_manager.SchedulerManager().get_scheduler()
         self.result = TelemetryJobStatus.FAILED_JOB_STATUS_INIT
+        self.executor = executor
 
     @staticmethod
     def get_instance(ctx, failed_task_id):
@@ -59,6 +60,7 @@ class FailedPerformanceCollectionHandler(object):
             failed_task[FailedTask.retry_count.name],
             failed_task[FailedTask.start_time.name],
             failed_task[FailedTask.end_time.name],
+            failed_task[FailedTask.executor.name],
         )
 
     def __call__(self):
@@ -118,4 +120,6 @@ class FailedPerformanceCollectionHandler(object):
         db.failed_task_update(self.ctx, self.failed_task_id,
                               {FailedTask.retry_count.name: self.retry_count,
                                FailedTask.result.name: self.result})
-        self.scheduler_instance.pause_job(self.job_id)
+        self.metrics_task_rpcapi.remove_failed_job(self.ctx,
+                                                   self.failed_task_id,
+                                                   self.executor)

--- a/delfin/task_manager/scheduler/schedulers/telemetry/job_handler.py
+++ b/delfin/task_manager/scheduler/schedulers/telemetry/job_handler.py
@@ -55,7 +55,8 @@ class JobHandler(object):
         this executor """
         try:
 
-            filters = {'executor': CONF.host}
+            filters = {'executor': CONF.host,
+                       'deleted': False}
             ctxt = context.get_admin_context()
             tasks = db.task_get_all(ctxt, filters=filters)
             failed_tasks = db.failed_task_get_all(ctxt, filters=filters)
@@ -88,6 +89,10 @@ class JobHandler(object):
 
         LOG.info("JobHandler received A job %s to schedule" % task_id)
         job = db.task_get(self.ctx, task_id)
+        # Check delete status of the task
+        deleted = job['deleted']
+        if deleted:
+            return
         collection_class = importutils.import_class(
             job['method'])
         instance = collection_class.get_instance(self.ctx, self.task_id)

--- a/delfin/task_manager/scheduler/schedulers/telemetry/job_handler.py
+++ b/delfin/task_manager/scheduler/schedulers/telemetry/job_handler.py
@@ -58,6 +58,7 @@ class JobHandler(object):
             filters = {'executor': CONF.host}
             ctxt = context.get_admin_context()
             tasks = db.task_get_all(ctxt, filters=filters)
+            failed_tasks = db.failed_task_get_all(ctxt, filters=filters)
             LOG.info("Scheduling boot time jobs for this executor: total "
                      "jobs to be handled :%s" % len(tasks))
             for task in tasks:
@@ -65,6 +66,13 @@ class JobHandler(object):
                 instance.schedule_job(task['id'])
                 LOG.debug('Periodic collection job assigned for id: '
                           '%s ' % task['id'])
+            for failed_task in failed_tasks:
+                instance = FailedJobHandler.get_instance(ctxt,
+                                                         failed_task['id'])
+                instance.schedule_failed_job(failed_task['id'])
+                LOG.debug('Failed job assigned for id: '
+                          '%s ' % failed_task['id'])
+
         except Exception as e:
             LOG.error("Failed to schedule boot jobs for this executor "
                       "reason: %s.",
@@ -106,7 +114,6 @@ class JobHandler(object):
                     performance_history_on_reschedule
                 end_time = current_time * 1000
                 start_time = end_time - (history_on_reschedule * 1000)
-                print(history_on_reschedule)
                 telemetry = PerformanceCollectionTask()
                 telemetry.collect(self.ctx, self.storage_id,
                                   self.args,

--- a/delfin/task_manager/scheduler/schedulers/telemetry/performance_collection_handler.py
+++ b/delfin/task_manager/scheduler/schedulers/telemetry/performance_collection_handler.py
@@ -107,7 +107,7 @@ class PerformanceCollectionHandler(object):
                            '.' + FailedPerformanceCollectionHandler.__name__,
                        FailedTask.retry_count.name: 0,
                        FailedTask.executor.name: self.executor}
-        db.failed_task_create(self.ctx, failed_task)
+        failed_task = db.failed_task_create(self.ctx, failed_task)
         self.metric_task_rpcapi.assign_failed_job(self.ctx,
-                                                  failed_task['task_id'],
+                                                  failed_task['id'],
                                                   failed_task['executor'])

--- a/delfin/task_manager/tasks/telemetry.py
+++ b/delfin/task_manager/tasks/telemetry.py
@@ -70,5 +70,3 @@ class PerformanceCollectionTask(TelemetryTask):
                       "storage id :{0}, reason:{1}".format(storage_id,
                                                            six.text_type(e)))
             return TelemetryTaskStatus.TASK_EXEC_STATUS_FAILURE
-
-

--- a/delfin/task_manager/tasks/telemetry.py
+++ b/delfin/task_manager/tasks/telemetry.py
@@ -71,11 +71,4 @@ class PerformanceCollectionTask(TelemetryTask):
                                                            six.text_type(e)))
             return TelemetryTaskStatus.TASK_EXEC_STATUS_FAILURE
 
-    def remove_telemetry(self, ctx, storage_id):
-        try:
-            db.task_delete_by_storage(ctx, storage_id)
-            db.failed_task_delete_by_storage(ctx, storage_id)
-        except Exception as e:
-            LOG.error("Failed to remove task entries from DB  for "
-                      "storage id :{0}, reason:{1}".format(storage_id,
-                                                           six.text_type(e)))
+

--- a/delfin/tests/unit/task_manager/scheduler/schedulers/telemetry/test_failed_performance_collection_handler.py
+++ b/delfin/tests/unit/task_manager/scheduler/schedulers/telemetry/test_failed_performance_collection_handler.py
@@ -44,6 +44,7 @@ fake_failed_job = {
     FailedTask.end_time.name: int(datetime.now().timestamp()) + 20,
     FailedTask.interval.name: 20,
     FailedTask.deleted.name: False,
+    FailedTask.executor.name: 'node1',
 }
 
 fake_deleted_storage_failed_job = {
@@ -59,12 +60,14 @@ fake_deleted_storage_failed_job = {
     FailedTask.end_time.name: int(datetime.now().timestamp()) + 20,
     FailedTask.interval.name: 20,
     FailedTask.deleted.name: True,
+    FailedTask.executor.name: 'node1',
 }
 
 fake_telemetry_job = {
     Task.id.name: 2,
     Task.storage_id.name: uuidutils.generate_uuid(),
     Task.args.name: {},
+    Task.executor.name: 'node1',
 }
 
 
@@ -78,13 +81,12 @@ class TestFailedPerformanceCollectionHandler(test.TestCase):
                        mock.Mock(return_value=fake_telemetry_job))
     @mock.patch.object(db, 'failed_task_get',
                        mock.Mock(return_value=fake_failed_job))
-    @mock.patch(
-        'apscheduler.schedulers.background.BackgroundScheduler.pause_job')
+    @mock.patch('delfin.task_manager.metrics_rpcapi.TaskAPI.remove_failed_job')
     @mock.patch('delfin.db.failed_task_update')
     @mock.patch('delfin.task_manager.tasks.telemetry'
                 '.PerformanceCollectionTask.collect')
     def test_failed_job_success(self, mock_collect_telemetry,
-                                mock_failed_task_update, mock_pause_job):
+                                mock_failed_task_update, mock_failed_job):
         mock_collect_telemetry.return_value = TelemetryTaskStatus. \
             TASK_EXEC_STATUS_SUCCESS
         ctx = context.get_admin_context()
@@ -93,7 +95,7 @@ class TestFailedPerformanceCollectionHandler(test.TestCase):
         # call failed job
         failed_job_handler()
 
-        self.assertEqual(mock_pause_job.call_count, 1)
+        self.assertEqual(mock_failed_job.call_count, 1)
         mock_failed_task_update.assert_called_once_with(
             ctx,
             fake_failed_job_id,
@@ -106,12 +108,11 @@ class TestFailedPerformanceCollectionHandler(test.TestCase):
                        mock.Mock(return_value=fake_telemetry_job))
     @mock.patch.object(db, 'failed_task_get',
                        mock.Mock(return_value=fake_failed_job))
-    @mock.patch(
-        'apscheduler.schedulers.background.BackgroundScheduler.pause_job')
+    @mock.patch('delfin.task_manager.metrics_rpcapi.TaskAPI.remove_failed_job')
     @mock.patch('delfin.db.failed_task_update')
     @mock.patch('delfin.task_manager.rpcapi.TaskAPI.collect_telemetry')
     def test_failed_job_failure(self, mock_collect_telemetry,
-                                mock_failed_task_update, mock_pause_job):
+                                mock_failed_task_update, mock_failed_job):
         mock_collect_telemetry.return_value = TelemetryTaskStatus. \
             TASK_EXEC_STATUS_FAILURE
         ctx = context.get_admin_context()
@@ -121,7 +122,7 @@ class TestFailedPerformanceCollectionHandler(test.TestCase):
         # call failed job
         failed_job_handler()
 
-        self.assertEqual(mock_pause_job.call_count, 0)
+        self.assertEqual(mock_failed_job.call_count, 0)
         mock_failed_task_update.assert_called_once_with(
             ctx,
             fake_failed_job_id,
@@ -133,12 +134,12 @@ class TestFailedPerformanceCollectionHandler(test.TestCase):
     @mock.patch.object(db, 'task_get',
                        mock.Mock(return_value=fake_telemetry_job))
     @mock.patch.object(db, 'failed_task_get')
-    @mock.patch(
-        'apscheduler.schedulers.background.BackgroundScheduler.pause_job')
+    @mock.patch('delfin.task_manager.metrics_rpcapi.TaskAPI.remove_failed_job')
     @mock.patch('delfin.db.failed_task_update')
     @mock.patch('delfin.task_manager.rpcapi.TaskAPI.collect_telemetry')
     def test_failed_job_fail_max_times(self, mock_collect_telemetry,
-                                       mock_failed_task_update, mock_pause_job,
+                                       mock_failed_task_update,
+                                       mock_remove_job,
                                        mock_failed_task_get):
         mock_collect_telemetry.return_value = TelemetryTaskStatus. \
             TASK_EXEC_STATUS_FAILURE
@@ -156,7 +157,7 @@ class TestFailedPerformanceCollectionHandler(test.TestCase):
         # call failed job
         failed_job_handler()
 
-        self.assertEqual(mock_pause_job.call_count, 1)
+        self.assertEqual(mock_remove_job.call_count, 1)
         mock_failed_task_update.assert_called_once_with(
             ctx,
             fake_failed_job_id,
@@ -170,8 +171,7 @@ class TestFailedPerformanceCollectionHandler(test.TestCase):
                        mock.Mock(return_value=fake_telemetry_job))
     @mock.patch.object(db, 'failed_task_get',
                        mock.Mock(return_value=fake_deleted_storage_failed_job))
-    @mock.patch(
-        'apscheduler.schedulers.background.BackgroundScheduler.pause_job')
+    @mock.patch('delfin.task_manager.metrics_rpcapi.TaskAPI.remove_failed_job')
     @mock.patch('delfin.db.failed_task_update')
     @mock.patch('delfin.task_manager.rpcapi.TaskAPI.collect_telemetry')
     def test_failed_job_deleted_storage(self, mock_collect_telemetry,
@@ -190,7 +190,7 @@ class TestFailedPerformanceCollectionHandler(test.TestCase):
                        mock.Mock(return_value=fake_telemetry_job))
     @mock.patch.object(db, 'failed_task_get', failed_task_not_found_exception)
     @mock.patch(
-        'apscheduler.schedulers.background.BackgroundScheduler.pause_job',
+        'delfin.task_manager.metrics_rpcapi.TaskAPI.remove_failed_job',
         mock.Mock())
     @mock.patch('delfin.db.failed_task_update')
     @mock.patch('delfin.task_manager.rpcapi.TaskAPI.collect_telemetry')
@@ -199,7 +199,7 @@ class TestFailedPerformanceCollectionHandler(test.TestCase):
         ctx = context.get_admin_context()
         failed_job_handler = FailedPerformanceCollectionHandler(
             ctx, 1122, '12c2d52f-01bc-41f5-b73f-7abf6f38a2a6', '',
-            1234, 2, 1122334400, 1122334800)
+            1234, 2, 1122334400, 1122334800, 'node1')
         failed_job_handler()
 
         # Verify that no action performed for deleted storage failed tasks

--- a/delfin/tests/unit/task_manager/scheduler/schedulers/telemetry/test_job_handler.py
+++ b/delfin/tests/unit/task_manager/scheduler/schedulers/telemetry/test_job_handler.py
@@ -41,6 +41,7 @@ fake_telemetry_job = {
     Task.method.name: constants.TelemetryCollection.PERFORMANCE_TASK_METHOD,
     Task.last_run_time.name: None,
     Task.executor.name: fake_executor,
+    Task.deleted.name: False,
 }
 
 fake_telemetry_jobs = [

--- a/delfin/tests/unit/task_manager/test_telemetry.py
+++ b/delfin/tests/unit/task_manager/test_telemetry.py
@@ -70,16 +70,3 @@ class TestPerformanceCollectionTask(test.TestCase):
         # when collect metric fails
         self.assertEqual(mock_dispatch.call_count, 0)
         self.assertEqual(mock_log_error.call_count, 1)
-
-    @mock.patch('delfin.db.failed_task_delete_by_storage')
-    @mock.patch('delfin.db.task_delete_by_storage')
-    def test_successful_remove(self, mock_task_del, mock_failed_task_del):
-        telemetry_obj = telemetry.PerformanceCollectionTask(
-        )
-        telemetry_obj.remove_telemetry(
-            context, 'c5c91c98-91aa-40e6-85ac-37a1d3b32bda')
-
-        mock_task_del.assert_called_with(
-            context, 'c5c91c98-91aa-40e6-85ac-37a1d3b32bda')
-        mock_failed_task_del.assert_called_with(
-            context, 'c5c91c98-91aa-40e6-85ac-37a1d3b32bda')

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ flask
 kafka-python
 importlib-metadata==3.7.0; python_version < "3.8"
 tenacity==6.3.1
+tzlocal<3.0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
After removing periodic scan of task and failed task tables we need to handle below scenarios

1. When a node restarts get all jobs assigned to it and schedule
2. When a leader switch happens reschedule failed_tasks
3. when a node down or up reschedule failed tasks
4. when a storage is deleted remove corresponding jobs from scheduler

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #NA

**Test notes**:
Following TC are executed with this PR

- make a telemetry collection failed :

Expected results 

            1.  An entry in failed_task table is created .
            2.  Scheduler receives a job to schedule failed_task again
            3.  Scheduler runs the failed job 
            4.  Success /Failure of result is updated in failed_task table

- make a failed_telemetry job fail continuously:

expected results:

        1. for each failure retry count is being updated
        2. after reaching max_retry the job has been removed and failed_task entry is also removed

- When a storage is deleted:

        1.  All task and failed_task entry for that storage is deleted
        2.  All scheduled job for corresponding storage has been deleted 

- When a node is down:

      1.  All task and failed_task assigned for this job is being re_distributed
      2.  new executor got assigned for the task
      3.  same  executor as parent task is assigned for the failed_task
      4.  assigned executor start collection for these tasks and failed_tasks

- When a node joins

          1.  all tasks and failed_task has got executors assinged
          2.  same  executor as parent task is assigned for the failed_task
          3.  assigned executor start collection for these tasks and failed_tasks
          4. same  executor as parent task is assigned for the failed_task

 


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
