### PR TITLE
Change get_capabilities to static method, and add filters parameter

### DIFF
--- a/delfin/drivers/dell_emc/vmax/vmax.py
+++ b/delfin/drivers/dell_emc/vmax/vmax.py
@@ -145,7 +145,8 @@ class VMAXStorageDriver(driver.StorageDriver):
 
         return metrics
 
-    def get_capabilities(self, context):
+    @staticmethod
+    def get_capabilities(context, filters=None):
         """Get capability of supported driver"""
         return {
             'is_historic': True,

--- a/delfin/drivers/driver.py
+++ b/delfin/drivers/driver.py
@@ -174,7 +174,8 @@ class StorageDriver(object):
         raise NotImplementedError(
             "Driver API list_shares() is not Implemented")
 
-    def get_capabilities(self, context):
+    @staticmethod
+    def get_capabilities(context, filters=None):
         """Get capability of driver"""
         pass
 

--- a/delfin/drivers/fake_storage/__init__.py
+++ b/delfin/drivers/fake_storage/__init__.py
@@ -558,7 +558,8 @@ class FakeStorageDriver(driver.StorageDriver):
             merged_metrics += m
         return merged_metrics
 
-    def get_capabilities(self, context):
+    @staticmethod
+    def get_capabilities(context, filters=None):
         """Get capability of supported driver"""
         return {
             'is_historic': False,

--- a/delfin/drivers/huawei/oceanstor/oceanstor.py
+++ b/delfin/drivers/huawei/oceanstor/oceanstor.py
@@ -600,7 +600,8 @@ class OceanStorDriver(driver.StorageDriver):
 
         return metrics
 
-    def get_capabilities(self, context):
+    @staticmethod
+    def get_capabilities(context, filters=None):
         """Get capability of supported driver"""
         return {
             'is_historic': False,

--- a/delfin/drivers/netapp/dataontap/cluster_mode.py
+++ b/delfin/drivers/netapp/dataontap/cluster_mode.py
@@ -86,5 +86,6 @@ class NetAppCmodeDriver(driver.StorageDriver):
         return self.netapp_handler.collect_perf_metrics(
             storage_id, resource_metrics, start_time, end_time)
 
-    def get_capabilities(self, context):
+    @staticmethod
+    def get_capabilities(context, filters=None):
         return constant.PERF_CAPABILITIES

--- a/delfin/tests/e2e/testdriver/__init__.py
+++ b/delfin/tests/e2e/testdriver/__init__.py
@@ -224,8 +224,9 @@ class TestDriver(driver.StorageDriver):
 
         return array_metrics
 
-    def get_capabilities(self, context):
-        """Get capability of supported driver"""
+    @staticmethod
+    def get_capabilities(context, filters=None):
+        """Get capability of supported driver."""
         return {
             'is_historic': False,
             'resource_metrics': {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In some scenarios, we need performance info of ` vendor > model` before driver class is instantiated, so method `get_capabilities` need to be static method. And also we need to get the performance info about the storage device which has been added in delfin, so the parameter `filters` be added to this method.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
