### PR TITLE
Changing Failed task schedule interval to 900 sec

### DIFF
--- a/delfin/common/constants.py
+++ b/delfin/common/constants.py
@@ -397,10 +397,8 @@ class TelemetryCollection(object):
     PERFORMANCE_TASK_METHOD = "delfin.task_manager.scheduler.schedulers." \
                               "telemetry.performance_collection_handler." \
                               "PerformanceCollectionHandler"
-    """Performance monitoring job interval"""
-    PERIODIC_JOB_INTERVAL = 180
     """Failed Performance monitoring job interval"""
-    FAILED_JOB_SCHEDULE_INTERVAL = 240
+    FAILED_JOB_SCHEDULE_INTERVAL = 900
     """Failed Performance monitoring retry count"""
     MAX_FAILED_JOB_RETRY_COUNT = 5
     """Default performance collection interval"""

--- a/delfin/task_manager/scheduler/schedulers/telemetry/performance_collection_handler.py
+++ b/delfin/task_manager/scheduler/schedulers/telemetry/performance_collection_handler.py
@@ -99,7 +99,7 @@ class PerformanceCollectionHandler(object):
         failed_task = {FailedTask.storage_id.name: self.storage_id,
                        FailedTask.task_id.name: self.task_id,
                        FailedTask.interval.name:
-                           TelemetryCollection.PERIODIC_JOB_INTERVAL,
+                           TelemetryCollection.FAILED_JOB_SCHEDULE_INTERVAL,
                        FailedTask.end_time.name: end_time,
                        FailedTask.start_time.name: start_time,
                        FailedTask.method.name:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently failed tasks are scheduled for 3 minutes interval and 4 retries. This would remove the failed task retry within 15 minutes. We need to increase the time window to retry failed tasks for at least one hour. solution is to increase the interval
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #702 

**Test report**:

- Registered VMAX storage using local simulator
- waited for first collection to trigger
- switched off VMAX simulator
- verified failed task entry in DB
- verified failed task interval is 900 sec and it retried till it reached MAX_RETRY_COUNT=5
 
![image](https://user-images.githubusercontent.com/45681499/133739979-4b6b0e40-e80e-4cb1-834c-05b6f1c24e1d.png)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
