### PR TITLE
Removing Ubuntu 16.04 env deploy from workflow as the support ended sept 20,2021

### DIFF
--- a/.github/workflows/delfin_ci.yml
+++ b/.github/workflows/delfin_ci.yml
@@ -8,7 +8,6 @@ jobs:
       max-parallel: 6
       matrix:
         platform:
-          - ubuntu-16.04
           - ubuntu-18.04
         python-version: [ 3.6, 3.7, 3.8 ]
 

--- a/.github/workflows/delfin_e2e_test.yml
+++ b/.github/workflows/delfin_e2e_test.yml
@@ -8,7 +8,6 @@ jobs:
       max-parallel: 6
       matrix:
         platform:
-          - ubuntu-16.04
           - ubuntu-18.04
         python-version: [ 3.6, 3.7, 3.8 ]
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Removing Ubuntu 16.04 env deploy from workflow as the support ended sept 20,2021 as per https://github.com/actions/virtual-environments/issues/3287

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
