### PR TITLE
Remove unused method from distributor

### DIFF
--- a/delfin/leader_election/distributor/task_distributor.py
+++ b/delfin/leader_election/distributor/task_distributor.py
@@ -18,7 +18,6 @@ from oslo_config import cfg
 from oslo_log import log
 
 from delfin import db
-from delfin.common.constants import TelemetryCollection
 from delfin.coordination import ConsistentHashing
 from delfin.task_manager import metrics_rpcapi as task_rpcapi
 
@@ -56,7 +55,3 @@ class TaskDistributor(object):
             LOG.error('Failed to distribute failed job, reason: %s',
                       six.text_type(e))
             raise e
-
-    @classmethod
-    def job_interval(cls):
-        return TelemetryCollection.PERIODIC_JOB_INTERVAL


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Remove unused method from distributor, 
TelemetryCollection.PERIODIC_JOB_INTERVAL and job_interval function is no more used , Removing the references.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
