### PR TITLE
Fixed error that we were getting while installing deflin through Installer.

### DIFF
--- a/installer/precheck
+++ b/installer/precheck
@@ -81,7 +81,7 @@ check_install_rabbitmq(){
     else
         #TODO check erlang
         # Import rabbitMQ
-        ret=$(wget -O- https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc | sudo apt-key add -)
+        ret=$(wget -O- https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc | sudo apt-key add -)
         if [ $? -eq 0 ]; then
             ret=$(wget -O- https://www.rabbitmq.com/rabbitmq-release-signing-key.asc | sudo apt-key add -)
             if [ $? -ne 0 ]; then


### PR DESCRIPTION
link on line 84 of file installer/precheck. The correct link i.e. https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc is replaced with the previous one.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
