### PR TITLE
 Adding overlap between collection intervals

### DIFF
--- a/delfin/common/config.py
+++ b/delfin/common/config.py
@@ -119,6 +119,11 @@ telemetry_opts = [
                .DEF_PERFORMANCE_HISTORY_ON_RESCHEDULE,
                help='default history(in sec) to be collected on a job '
                     'reschedule'),
+    cfg.IntOpt('performance_timestamp_overlap',
+               default=constants.TelemetryCollection
+               .DEF_PERFORMANCE_TIMESTAMP_OVERLAP,
+               help='default overlap to be added on start_time in sec  '
+               ),
     cfg.BoolOpt('enable_dynamic_subprocess',
                 default=False,
                 help='Enable dynamic subprocess metrics collection'),

--- a/delfin/common/constants.py
+++ b/delfin/common/constants.py
@@ -404,6 +404,7 @@ class TelemetryCollection(object):
     """Default performance collection interval"""
     DEF_PERFORMANCE_COLLECTION_INTERVAL = 900
     DEF_PERFORMANCE_HISTORY_ON_RESCHEDULE = 1800
+    DEF_PERFORMANCE_TIMESTAMP_OVERLAP = 60
 
 
 class TelemetryTaskStatus(object):

--- a/delfin/task_manager/scheduler/schedulers/telemetry/performance_collection_handler.py
+++ b/delfin/task_manager/scheduler/schedulers/telemetry/performance_collection_handler.py
@@ -15,6 +15,8 @@
 from datetime import datetime
 
 import six
+from oslo_config import cfg
+
 from delfin.task_manager.scheduler.schedulers.telemetry. \
     failed_performance_collection_handler import \
     FailedPerformanceCollectionHandler
@@ -28,6 +30,7 @@ from delfin.task_manager import metrics_rpcapi as metrics_task_rpcapi
 from delfin.task_manager.scheduler import schedule_manager
 from delfin.task_manager.tasks.telemetry import PerformanceCollectionTask
 
+CONF = cfg.CONF
 LOG = log.getLogger(__name__)
 
 
@@ -74,8 +77,10 @@ class PerformanceCollectionHandler(object):
             current_time = int(datetime.now().timestamp())
 
             # Times are epoch time in milliseconds
+            overlap = CONF.telemetry. \
+                performance_timestamp_overlap
             end_time = current_time * 1000
-            start_time = end_time - (self.interval * 1000)
+            start_time = end_time - (self.interval * 1000) - (overlap * 1000)
             telemetry = PerformanceCollectionTask()
             status = telemetry.collect(self.ctx, self.storage_id, self.args,
                                        start_time, end_time)

--- a/delfin/task_manager/scheduler/schedulers/telemetry/performance_collection_handler.py
+++ b/delfin/task_manager/scheduler/schedulers/telemetry/performance_collection_handler.py
@@ -17,9 +17,6 @@ from datetime import datetime
 import six
 from oslo_config import cfg
 
-from delfin.task_manager.scheduler.schedulers.telemetry. \
-    failed_performance_collection_handler import \
-    FailedPerformanceCollectionHandler
 
 from oslo_log import log
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
If Delfin and storage device/ device manager has different time set, the metric collection would miss some time stamp in below scenarios
-Delfin node time is ahead of the actual time
-Storage device/ device manager is behind actual time
-Both sample generation and delfin collection trigger has a coincidence
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #759 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
