### PR TITLE
Failed task scheduling based on driver capability

### DIFF
--- a/delfin/api/schemas/storage_capabilities_schema.py
+++ b/delfin/api/schemas/storage_capabilities_schema.py
@@ -16,6 +16,7 @@ STORAGE_CAPABILITIES_SCHEMA = {
     'type': 'object',
     'properties': {
         'is_historic': {'type': 'boolean'},
+        'performance_metric_retention_window': {'type': 'integer'},
         'resource_metrics': {
             'type': 'object',
             'properties': {

--- a/delfin/common/config.py
+++ b/delfin/common/config.py
@@ -119,6 +119,11 @@ telemetry_opts = [
                .DEF_PERFORMANCE_HISTORY_ON_RESCHEDULE,
                help='default history(in sec) to be collected on a job '
                     'reschedule'),
+    cfg.IntOpt('max_failed_task_retry_window',
+               default=constants.TelemetryCollection
+               .MAX_FAILED_TASK_RETRY_WINDOW,
+               help='Maximum time window (in sec) until which delfin supports '
+                    'collection for failed tasks'),
     cfg.BoolOpt('enable_dynamic_subprocess',
                 default=False,
                 help='Enable dynamic subprocess metrics collection'),

--- a/delfin/common/constants.py
+++ b/delfin/common/constants.py
@@ -404,6 +404,8 @@ class TelemetryCollection(object):
     """Default performance collection interval"""
     DEF_PERFORMANCE_COLLECTION_INTERVAL = 900
     DEF_PERFORMANCE_HISTORY_ON_RESCHEDULE = 1800
+    """Maximum failed task retry window in seconds"""
+    MAX_FAILED_TASK_RETRY_WINDOW = 7200
 
 
 class TelemetryTaskStatus(object):

--- a/delfin/drivers/fake_storage/__init__.py
+++ b/delfin/drivers/fake_storage/__init__.py
@@ -564,6 +564,7 @@ class FakeStorageDriver(driver.StorageDriver):
         """Get capability of supported driver"""
         return {
             'is_historic': False,
+            'performance_metric_retention_window': 4500,
             'resource_metrics': {
                 "storage": {
                     "throughput": {

--- a/delfin/tests/unit/task_manager/scheduler/schedulers/telemetry/test_performance_collection_handler.py
+++ b/delfin/tests/unit/task_manager/scheduler/schedulers/telemetry/test_performance_collection_handler.py
@@ -82,10 +82,14 @@ class TestPerformanceCollectionHandler(test.TestCase):
     @mock.patch('delfin.db.failed_task_create')
     @mock.patch('delfin.task_manager.tasks.telemetry'
                 '.PerformanceCollectionTask.collect')
-    def test_performance_collection_failure(self, mock_collect_telemetry,
+    @mock.patch('delfin.drivers.api.API.get_capabilities')
+    def test_performance_collection_failure(self, mock_get_capabilities,
+                                            mock_collect_telemetry,
                                             mock_failed_task_create,
                                             mock_assign_failed_job,
                                             mock_task_update):
+
+        mock_get_capabilities.return_value = {}
         mock_collect_telemetry.return_value = TelemetryTaskStatus. \
             TASK_EXEC_STATUS_FAILURE
         ctx = context.get_admin_context()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR addresses the failed task scheduling mechanism considering the driver capability about performance metric retention window.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This PR addresses the issue https://github.com/sodafoundation/delfin/issues/757

**Special notes for your reviewer**:
Test scenarios verified here are:
> Driver supports performance_metric_retention_window which is less than delfin max collection window
> Driver supports performance_metric_retention_window which is more than delfin max collection window
> Driver does not support performance_metric_retention_window -> use default interval
> Driver throws exception for get_driver_capabilites

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
