### PR TITLE
Add a new storage status "unknown".

### DIFF
--- a/delfin/common/constants.py
+++ b/delfin/common/constants.py
@@ -30,8 +30,9 @@ class StorageStatus(object):
     OFFLINE = 'offline'
     ABNORMAL = 'abnormal'
     DEGRADED = 'degraded'
+    UNKNOWN = 'unknown'
 
-    ALL = (NORMAL, OFFLINE, ABNORMAL, DEGRADED)
+    ALL = (NORMAL, OFFLINE, ABNORMAL, DEGRADED, UNKNOWN)
 
 
 class StoragePoolStatus(object):


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There is a storage status named "unknown" in Dell EMC Unity, maybe we should add a more accurate status for device.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
