### PR TITLE
Add a interface for get the timestamp of the latest performance data …

### DIFF
--- a/delfin/common/constants.py
+++ b/delfin/common/constants.py
@@ -39,8 +39,9 @@ class StoragePoolStatus(object):
     NORMAL = 'normal'
     OFFLINE = 'offline'
     ABNORMAL = 'abnormal'
+    UNKNOWN = 'unknown'
 
-    ALL = (NORMAL, OFFLINE, ABNORMAL)
+    ALL = (NORMAL, OFFLINE, ABNORMAL, UNKNOWN)
 
 
 class VolumeStatus(object):

--- a/delfin/drivers/driver.py
+++ b/delfin/drivers/driver.py
@@ -289,3 +289,7 @@ class StorageDriver(object):
 
     def get_alert_sources(self, context):
         return []
+
+    def get_latest_perf_timestamp(self, context):
+        """Get the timestamp of the latest performance data of the device"""
+        pass


### PR DESCRIPTION
Add a interface for get the timestamp of the latest performance data of the device and add an unknown enum of the storage pool status.

What this PR does / why we need it:

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #783 

Special notes for your reviewer:

Release note: