### PR TITLE
Add get_latest_perf_timestamp() api to vmax

### DIFF
--- a/delfin/drivers/dell_emc/vmax/perf_utils.py
+++ b/delfin/drivers/dell_emc/vmax/perf_utils.py
@@ -31,8 +31,8 @@ def parse_performance_data(metrics):
 
 def construct_metrics(storage_id, resource_metrics, unit_map, perf_list):
     metrics_list = []
-    metrics_values = {}
     for perf in perf_list:
+        metrics_values = {}
         collected_metrics_list = perf.get('metrics')
         for collected_metrics in collected_metrics_list:
             metrics_map = parse_performance_data(collected_metrics)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add get_latest_perf_timestamp() api to vmax


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
