### PR TITLE
Add an enumerated value "degraded" for disk status.

### DIFF
--- a/delfin/common/constants.py
+++ b/delfin/common/constants.py
@@ -144,9 +144,10 @@ class PortLogicalType(object):
 class DiskStatus(object):
     NORMAL = 'normal'
     ABNORMAL = 'abnormal'
+    DEGRADED = 'degraded'
     OFFLINE = 'offline'
 
-    ALL = (NORMAL, ABNORMAL, OFFLINE)
+    ALL = (NORMAL, ABNORMAL, DEGRADED, OFFLINE)
 
 
 class DiskPhysicalType(object):


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There is a "Degraded" status of disk in HPE 3PAR, I think we should add it as an enumerated value of disk status.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
