### PR TITLE
Add a performance metric "ioSize" of filesystem.

### DIFF
--- a/delfin/api/schemas/storage_capabilities_schema.py
+++ b/delfin/api/schemas/storage_capabilities_schema.py
@@ -565,6 +565,15 @@ STORAGE_CAPABILITIES_SCHEMA = {
                                                 'maxLength': 255}
                             },
                         },
+                        'ioSize': {
+                            'type': 'object',
+                            'properties': {
+                                'unit': {'type': 'string', 'enum': ["KB"]},
+                                'description': {'type': 'string',
+                                                'minLength': 1,
+                                                'maxLength': 255}
+                            },
+                        },
                         'readIoSize': {
                             'type': 'object',
                             'properties': {

--- a/delfin/drivers/driver.py
+++ b/delfin/drivers/driver.py
@@ -176,7 +176,9 @@ class StorageDriver(object):
 
     @staticmethod
     def get_capabilities(context, filters=None):
-        """Get capability of driver"""
+        """Get capability of driver, please refer to
+        STORAGE_CAPABILITIES_SCHEMA
+        in api/schemas/storage_capabilities_schema.py."""
         pass
 
     def list_storage_host_initiators(self, context):

--- a/delfin/drivers/fake_storage/__init__.py
+++ b/delfin/drivers/fake_storage/__init__.py
@@ -840,6 +840,11 @@ class FakeStorageDriver(driver.StorageDriver):
                         "unit": "IOPS",
                         "description": "Write operations per second"
                     },
+                    "ioSize": {
+                        "unit": "KB",
+                        "description": "The average size of IO requests "
+                                       "in KB."
+                    },
                     "readIoSize": {
                         "unit": "KB",
                         "description": "The average size of read IO requests "
@@ -847,7 +852,7 @@ class FakeStorageDriver(driver.StorageDriver):
                     },
                     "writeIoSize": {
                         "unit": "KB",
-                        "description": "The average size of read IO requests"
+                        "description": "The average size of write IO requests"
                                        " in KB."
                     },
                 },

--- a/delfin/tests/unit/api/fakes.py
+++ b/delfin/tests/unit/api/fakes.py
@@ -741,6 +741,11 @@ def fake_get_capabilities(context, storage_id):
                         "unit": "IOPS",
                         "description": "Write operations per second"
                     },
+                    "ioSize": {
+                        "unit": "KB",
+                        "description": "The average size of IO requests "
+                                       "in KB."
+                    },
                     "readIoSize": {
                         "unit": "KB",
                         "description": "The average size of read IO requests "
@@ -748,7 +753,7 @@ def fake_get_capabilities(context, storage_id):
                     },
                     "writeIoSize": {
                         "unit": "KB",
-                        "description": "The average size of read IO requests"
+                        "description": "The average size of write IO requests"
                                        " in KB."
                     },
                 },


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There is a performance metric "ioSize" of filesystem in Dell EMC Unity, I think it needs to be collected in delfin.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
