### PR TITLE
Added Limitation section in documentation

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -189,3 +189,5 @@ The logs can be uniquely identified based upon the timestamp.
   4. [Optional] If prometheus is configured, monitor the performance metrics on prometheus server at default location
 
      http://localhost:9090/graph
+
+# Limitation

--- a/installer/README.md
+++ b/installer/README.md
@@ -191,3 +191,4 @@ The logs can be uniquely identified based upon the timestamp.
      http://localhost:9090/graph
 
 # Limitation
+Local installation, unlike Ansible installer, does not support SODA Dashboard integration.


### PR DESCRIPTION
Local installation, unlike Ansible installer, does not support SODA Dashboard integration limitation had been found and added to the documentation section.
