### PR TITLE
Capture git clone steps to local installer Readme #841

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -22,6 +22,7 @@ Ubuntu 16.04, Ubuntu 18.04
 - #### Set PYTHONPATH to working directory
 
     ```sh
+    git clone https://github.com/sodafoundation/delfin.git
     export PYTHONPATH=$(pwd)
     ```
 
@@ -62,6 +63,7 @@ Install: Installs and starts the delfin process
 Uninstall: Uninstalls the delfin. Doesn't uninstall the required components. You may need to uninstall it explicitly using the native approach.
 
 # How to install
+cd delfin
 To get help, execute 'install -h'. It will show help information
 
 Install script can be executed with three different switches to:

--- a/installer/README.md
+++ b/installer/README.md
@@ -23,6 +23,7 @@ Ubuntu 16.04, Ubuntu 18.04
 
     ```sh
     git clone https://github.com/sodafoundation/delfin.git
+    cd delfin
     export PYTHONPATH=$(pwd)
     ```
 
@@ -63,7 +64,7 @@ Install: Installs and starts the delfin process
 Uninstall: Uninstalls the delfin. Doesn't uninstall the required components. You may need to uninstall it explicitly using the native approach.
 
 # How to install
-cd delfin
+
 To get help, execute 'install -h'. It will show help information
 
 Install script can be executed with three different switches to:


### PR DESCRIPTION
Added steps to capture git clone steps to local installer Readme:
delfin/installer/README.md
**Changes **
 
-Between line 24 and 25 added     git clone https://github.com/sodafoundation/delfin.git
-line 66 cd delfin

regards
your contributor
@shelar1423 