### PR TITLE
Add Centralized Manager support

### DIFF
--- a/delfin/alert_manager/trap_receiver.py
+++ b/delfin/alert_manager/trap_receiver.py
@@ -182,12 +182,7 @@ class TrapReceiver(manager.Manager):
         if not alert_source:
             raise exception.AlertSourceNotFoundWithHost(source_ip)
 
-        # This is to make sure unique host is configured each alert source
-        if len(alert_source) > 1:
-            msg = (_("Failed to get unique alert source with host %s.")
-                   % source_ip)
-            raise exception.InvalidResults(msg)
-
+        # Return first configured source that can handle the trap
         return alert_source[0]
 
     def _cb_fun(self, state_reference, context_engine_id, context_name,

--- a/delfin/api/schemas/storages.py
+++ b/delfin/api/schemas/storages.py
@@ -19,6 +19,7 @@ create = {
     'properties': {
         'vendor': {'type': 'string', 'minLength': 1, 'maxLength': 255},
         'model': {'type': 'string', 'minLength': 1, 'maxLength': 255},
+        'storage_name': {'type': 'string', 'minLength': 1, 'maxLength': 255},
         'rest': {
             'type': 'object',
             'properties': {

--- a/delfin/context.py
+++ b/delfin/context.py
@@ -71,6 +71,7 @@ class RequestContext(context.RequestContext):
         self.user_id = self.user
         self.tenant = project_id or tenant
         self.project_id = self.tenant
+        self.storage_id = None
 
         self.read_deleted = read_deleted
         self.remote_address = remote_address
@@ -107,6 +108,7 @@ class RequestContext(context.RequestContext):
         values.update({
             'user_id': getattr(self, 'user_id', None),
             'project_id': getattr(self, 'project_id', None),
+            'storage_id': getattr(self, 'storage_id', None),
             'read_deleted': getattr(self, 'read_deleted', None),
             'remote_address': getattr(self, 'remote_address', None),
             'timestamp': self.timestamp.isoformat() if hasattr(

--- a/delfin/db/sqlalchemy/models.py
+++ b/delfin/db/sqlalchemy/models.py
@@ -51,6 +51,7 @@ class AccessInfo(BASE, DelfinBase):
     """Represent access info required for storage accessing."""
     __tablename__ = "access_info"
     storage_id = Column(String(36), primary_key=True)
+    storage_name = Column(String(255))
     vendor = Column(String(255))
     model = Column(String(255))
     rest = Column(JsonEncodedDict)

--- a/delfin/drivers/api.py
+++ b/delfin/drivers/api.py
@@ -68,6 +68,8 @@ class API(object):
 
     def remove_storage(self, context, storage_id):
         """Clear driver instance from driver factory."""
+        driver = self.driver_manager.get_driver(context, storage_id=storage_id)
+        driver.delete_storage(context)
         self.driver_manager.remove_driver(storage_id)
 
     def get_storage(self, context, storage_id):

--- a/delfin/drivers/driver.py
+++ b/delfin/drivers/driver.py
@@ -28,6 +28,14 @@ class StorageDriver(object):
         """
         self.storage_id = kwargs.get('storage_id', None)
 
+    def delete_storage(self, context):
+        """Cleanup storage device information from driver"""
+        pass
+
+    def add_storage(self, kwargs):
+        """Add storage device information to driver"""
+        pass
+
     @abc.abstractmethod
     def reset_connection(self, context, **kwargs):
         """ Reset connection with backend with new args """

--- a/delfin/task_manager/manager.py
+++ b/delfin/task_manager/manager.py
@@ -21,6 +21,7 @@ from oslo_utils import importutils
 
 from delfin import manager
 from delfin.drivers import manager as driver_manager
+from delfin.drivers import api as driver_api
 from delfin.task_manager.tasks import alerts, telemetry
 
 LOG = log.getLogger(__name__)
@@ -51,6 +52,7 @@ class TaskManager(manager.Manager):
     def remove_storage_in_cache(self, context, storage_id):
         LOG.info('Remove storage device in memory for storage id:{0}'
                  .format(storage_id))
+        driver_api.API().remove_storage(context, storage_id)
         drivers = driver_manager.DriverManager()
         drivers.remove_driver(storage_id)
 

--- a/delfin/tests/unit/alert_manager/test_alert_processor.py
+++ b/delfin/tests/unit/alert_manager/test_alert_processor.py
@@ -88,7 +88,7 @@ class AlertProcessorTestCase(unittest.TestCase):
 
         # Verify that model returned by driver is exported
         mock_export_model.assert_called_once_with(expected_ctxt,
-                                                  expected_alert_model)
+                                                  [expected_alert_model])
 
     @mock.patch('delfin.db.storage_get')
     @mock.patch('delfin.drivers.api.API.parse_alert',

--- a/delfin/tests/unit/api/fakes.py
+++ b/delfin/tests/unit/api/fakes.py
@@ -155,7 +155,7 @@ def fake_access_info_get_all(context, marker=None, limit=None, sort_keys=None,
             'vendor': 'fake_storage',
             'rest': {
                 'host': '10.0.0.76',
-                'port': '1234',
+                'port': 1234,
                 'username': 'admin',
                 'password': b'YWJjZA=='
             },

--- a/delfin/tests/unit/api/v1/test_access_info.py
+++ b/delfin/tests/unit/api/v1/test_access_info.py
@@ -42,6 +42,7 @@ class TestAccessInfoController(test.TestCase):
             "model": "fake_driver",
             "vendor": "fake_storage",
             "storage_id": "865ffd4d-f1f7-47de-abc3-5541ef44d0c1",
+            "storage_name": None,
             "rest": {
                 "host": "10.0.0.0",
                 "port": 1234,
@@ -95,6 +96,7 @@ class TestAccessInfoController(test.TestCase):
             "model": "fake_driver",
             "vendor": "fake_storage",
             "storage_id": "865ffd4d-f1f7-47de-abc3-5541ef44d0c1",
+            "storage_name": None,
             "rest": {
                 "username": "admin_modified",
                 "host": "10.0.0.0",
@@ -124,6 +126,7 @@ class TestAccessInfoController(test.TestCase):
                 "model": "fake_driver",
                 "vendor": "fake_storage",
                 "storage_id": "865ffd4d-f1f7-47de-abc3-5541ef44d0c1",
+                "storage_name": None,
                 "rest": {
                     "host": "10.0.0.0",
                     "port": 1234,

--- a/delfin/tests/unit/drivers/test_api.py
+++ b/delfin/tests/unit/drivers/test_api.py
@@ -190,12 +190,14 @@ class TestDriverAPI(TestCase):
         msg = "Storage backend could not be found"
         self.assertIn(msg, str(exc.exception))
 
+    @mock.patch('delfin.drivers.manager.DriverManager.get_driver')
     @mock.patch('delfin.db.storage_get')
     @mock.patch('delfin.db.storage_create')
     @mock.patch('delfin.db.access_info_create')
     @mock.patch('delfin.db.storage_get_all')
     def test_remove_storage(self, mock_storage, mock_access_info,
-                            mock_storage_create, mock_get_storage):
+                            mock_storage_create, mock_get_storage,
+                            mock_dm):
         storage = copy.deepcopy(STORAGE)
         storage['id'] = '12345'
         mock_storage.return_value = None
@@ -204,6 +206,7 @@ class TestDriverAPI(TestCase):
         api = API()
         api.discover_storage(context, ACCESS_INFO)
         mock_get_storage.return_value = None
+        mock_dm.return_value = FakeStorageDriver()
 
         storage_id = '12345'
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add Centralized Manager support

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #549 

**Special notes for your reviewer**:

Link to Design document: https://github.com/sodafoundation/architecture-analysis/pull/120

This feature is verified using VMAX simulator.
Following is the steps to run VMAX Simulator in an Ubuntu 18.04 machine.
```bash
git clone https://github.com/joseph-v/delfin.git
cd delfin
git checkout vmax-simulator-cm
virtualenv venv
source venv/bin/activate
pip install -r requirements.txt
cd delfin/tests/simulator/dell_emc/
mkdir -p vmax/data
pip install flask_restful
python vmax/vmax.py
```

This will start a VMAX simulator on the http://localhost:8443

**To Test Centralized Manager feature with VMAX Simulator:**
1. Start the delfin processes of (api.py, task.py & alert.py) and register VMAX storage with following commands. Storages should be successfully registered and resource and metrics collection logs can be verified from VMAX simulator and Delfin processes

```bash
# First storage
curl --location --request POST 'http://127.0.0.1:8190/v1/storages' \
--header 'Content-Type: application/json' \
--data-raw '{
    "vendor":"dellemc",
    "model":"vmax",
    "storage_name": "000196700153",
    "rest": {
        "host": "127.0.0.1",
        "port":8443,
        "username":"admin",
        "password":"password"
    }
}'

# Second storage
curl --location --request POST 'http://127.0.0.1:8190/v1/storages' \
--header 'Content-Type: application/json' \
--data-raw '{
    "vendor":"dellemc",
    "model":"vmax",
    "storage_name": "000196700154",
    "rest": {
        "host": "127.0.0.1",
        "port":8443,
        "username":"admin",
        "password":"password"
    }
}'
```
2. Register VMAX with any other "storage_name" should result in error response
3. Register an already registered storage_name should result in error response

**To Test Centralized Manager feature with Embedded array using fake driver:**

1. Register fake driver without "storage_name" in access_info, should result in success
```bash
curl --location --request POST 'http://127.0.0.1:8190/v1/storages' \
--header 'Content-Type: application/json' \
--data-raw '{
    "vendor":"fake_storage",
    "model":"fake_driver",
    "rest": {
        "host": "127.0.0.1",
        "port":8000,
        "username":"admin",
        "password":"password"
    }
}'
```
2. Repeat above register request, should result in error response (StorageAlreadyExists error)
3. Repeat above register request by adding "storage_name", should result in success

**To Test SNMP Alert using VMAX Simulator:**

1. Add `trap_receiver_port = 8162` to delfin.conf, under [DEFAULT]
5. Start  delfin/cmd/alert.py --config-file=/etc/delfin/delfin.conf
6. Configure SNMP for the array, Eg
```bash
curl --location --request PUT 'http://127.0.0.1:8190/v1/storages/01c0cf16-b595-4364-b5fd-8a4752120b71/snmp-config' \
--header 'Content-Type: application/json' \
--data-raw '{
  "version": "snmpv2c",
  "community_string": "public",
  "port": 8162,
  "host": "127.0.0.1"
}'
```
7. Send alert to above storage using following python script, snmptest.py using (command: `python snmptest.py 000196700153`)

```python
import sys

from pysnmp.hlapi import *

mib = {
    ObjectIdentifier('1.3.6.1.3.94.1.11.1.3'): 123,
    ObjectIdentifier('1.3.6.1.4.1.1139.3.8888.2.0'): 'emcAsyncEventCode'
}


def main(argv):

    storage_id = argv[1]
    if not storage_id:
        storage_id = '000196700153'
    print("Sending SNMP alert to storage: ", storage_id)
    iterator = sendNotification(
        SnmpEngine(),
        CommunityData('public', mpModel=0),
        UdpTransportTarget(('127.0.0.1', 8162)),
        ContextData(),
        'trap',
        [
            ObjectType(ObjectIdentity('1.3.6.1.3.94.1.11.1.3'), OctetString('connUnitEventId')),
            ObjectType(ObjectIdentity('1.3.6.1.4.1.1139.3.8888.1.0.0'), OctetString('emcAsyncEventSource')),
            ObjectType(ObjectIdentity('1.3.6.1.4.1.1139.3.8888.2.0.0'), OctetString('emcAsyncEventCode')),
            ObjectType(ObjectIdentity('1.3.6.1.4.1.1139.3.8888.3.0.0'), OctetString('emcAsyncEventComponentType')),
            ObjectType(ObjectIdentity('1.3.6.1.4.1.1139.3.8888.4.0.0'), OctetString('emcAsyncEventComponentName')),
            ObjectType(ObjectIdentity('1.3.6.1.3.94.1.11.1.3.0'), OctetString('connUnitEventId')),
            ObjectType(ObjectIdentity('1.3.6.1.3.94.1.11.1.6.0'), OctetString('connUnitEventSeverity')),
            ObjectType(ObjectIdentity('1.3.6.1.3.94.1.11.1.7.0'), OctetString('connUnitEventType')),
            ObjectType(ObjectIdentity('1.3.6.1.3.94.1.11.1.8.0'), OctetString('connUnitEventObject')),
            ObjectType(ObjectIdentity('1.3.6.1.3.94.1.11.1.9.0'), OctetString('connUnitEventDescr')),
            ObjectType(ObjectIdentity('1.3.6.1.3.94.1.6.1.20.0'), OctetString(storage_id)),
            ObjectType(ObjectIdentity('1.3.6.1.3.94.1.6.1.3.0'), OctetString('connUnitType')),
        ]
    )

    errorIndication, errorStatus, errorIndex, varBinds = next(iterator)

    if errorIndication:
        print(errorIndication)
    print("SNMP Alert Successfully send! ")


if __name__ == '__main__':
    main(sys.argv)

```
9. Check logs from alert process, that SNMP Trap is received by alert process and dispatched

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
This feature is verified only with VMAX simulator and fake driver, and not verified in Hardware