### PR TITLE
the updated swagger file

### DIFF
--- a/openapi-spec/swagger.yaml
+++ b/openapi-spec/swagger.yaml
@@ -3539,7 +3539,7 @@ components:
       description: Response for all access infos configuration.
       type: object
       properties:
-        snmp_configs:
+        access_infos:
           type: array
           description: the list of access info
           items:


### PR DESCRIPTION
***issue/Feature description.*****
GET/ v1/storages/access-infos is showing snmp_config instead of "access_infos" 
and also description showing snmp_config.

<!-- Thanks for sending a pull request! -->
 
**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
![Screenshot (11)](https://user-images.githubusercontent.com/103172664/165319804-355744a7-7ec8-4285-9fa5-db3aabeaf22b.png)
