### PR TITLE
[swagger file update] v1/storages not showing proper output

### DIFF
--- a/openapi-spec/swagger.yaml
+++ b/openapi-spec/swagger.yaml
@@ -4210,7 +4210,7 @@ components:
       description: Response for all snmp alert source configuration.
       type: object
       properties:
-        snmp_configs:
+        access_info:
           type: array
           description: the list of snmp configs
           items:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

get/v1/storages/access_info is showing "snmp_config" instead of "access_info" and also description also showing snmp_config
![1](https://user-images.githubusercontent.com/76615492/165327824-1fb0353a-c01f-4b97-b7c0-38945033f742.jpg)


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
