### PR TITLE
fixes issue #886

### DIFF
--- a/delfin/db/sqlalchemy/api.py
+++ b/delfin/db/sqlalchemy/api.py
@@ -2969,7 +2969,7 @@ def process_sort_params(sort_keys, sort_dirs, default_keys=None,
                 raise exception.InvalidInput(msg)
             result_dirs.append(sort_dir)
     else:
-        result_dirs = [default_dir_value for _sort_key in result_keys]
+        result_dirs = [default_dir_value for _ in result_keys]
 
     # Ensure that the key and direction length match
     while len(result_dirs) < len(result_keys):


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed un-used parameter _sort_key from delfin/db/sqlalchemy/api.py and replaced it with 


**Which issue this PR fixes**: 
fixes #886 

**Special notes for your reviewer**:
SODACODE 2022

