### PR TITLE
Replaced un-used variable _sort_key in delfin/common/sqlalchemyutils.py

### DIFF
--- a/delfin/common/sqlalchemyutils.py
+++ b/delfin/common/sqlalchemyutils.py
@@ -103,7 +103,7 @@ def paginate_query(query, model, limit, sort_keys, marker=None,
 
     # Ensure a per-column sort direction
     if sort_dirs is None:
-        sort_dirs = [sort_dir for _sort_key in sort_keys]
+        sort_dirs = [sort_dir for _ in sort_keys]
 
     if len(sort_dirs) != len(sort_keys):
         raise AssertionError(


### PR DESCRIPTION

The PR replaces the unused variable '_sort_key_ ' with " _ " (underscore) in delfin/common/sqlalchemyutils.py : line 106

This PR fixes #885.
