### PR TITLE
vsp change get volume's rule when it's id is not continuity

### DIFF
--- a/delfin/drivers/hitachi/vsp/consts.py
+++ b/delfin/drivers/hitachi/vsp/consts.py
@@ -18,3 +18,5 @@ BLOCK_SIZE = 512
 LDEV_NUMBER_OF_PER_REQUEST = 300
 SUPPORTED_VSP_SERIES = ('VSP G350', 'VSP G370', 'VSP G700', 'VSP G900',
                         'VSP F350', 'VSP F370', 'VSP F700', 'VSP F900')
+# the max number when get volumes in a request
+MAX_VOLUME_NUMBER = 16384

--- a/delfin/drivers/hitachi/vsp/rest_handler.py
+++ b/delfin/drivers/hitachi/vsp/rest_handler.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 import threading
+import time
 
 import requests
 import six
@@ -221,7 +222,7 @@ class RestHandler(RestClient):
 
     def get_volumes(self, head_id,
                     max_number=consts.LDEV_NUMBER_OF_PER_REQUEST):
-        url = '%s/%s/ldevs?headLdevId=%s&count=%s' % \
+        url = '%s/%s/ldevs?headLdevId=%s&count=%s&ldevOption=defined' % \
               (RestHandler.COMM_URL, self.storage_device_id, head_id,
                max_number)
         result_json = self.get_rest_info(url)
@@ -295,4 +296,13 @@ class RestHandler(RestClient):
               (RestHandler.COMM_URL, self.storage_device_id, port_id,
                group_number)
         result_json = self.get_rest_info(url)
+        return result_json
+
+    def get_volumes_with_defined(self):
+        url = '%s/%s/ldevs?ldevOption=defined&count=%s' % \
+              (RestHandler.COMM_URL, self.storage_device_id,
+               consts.MAX_VOLUME_NUMBER)
+        LOG.info('get volume start time:%s' % time.time())
+        result_json = self.get_rest_info(url, timeout=None)
+        LOG.info('get volume end time:%s' % time.time())
         return result_json

--- a/delfin/tests/unit/drivers/hitachi/vsp/test_hitachi_vspstor.py
+++ b/delfin/tests/unit/drivers/hitachi/vsp/test_hitachi_vspstor.py
@@ -135,10 +135,6 @@ GET_ALL_VOLUMES = {
             "ssid": "0004",
             "resourceGroupId": 0,
             "isAluaEnabled": False
-        },
-        {
-            "ldevId": 0,
-            "emulationType": "NOT DEFINED",
         }
     ]
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
vsp volume has the type of not defined，this pr is to exclude this kind of volume

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
