### PR TITLE
Update name of delfin redis container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     container_name: ${DELFIN_REDIS_HOSTNAME:-redis}
     command: redis-server
     ports:
-      - 6379:6379
+      - ${DELFIN_REDIS_PORT:-6379}:6379
     restart: always
 
   rabbitmq:

--- a/installer/ansible/roles/delfin-installer/scenarios/container.yml
+++ b/installer/ansible/roles/delfin-installer/scenarios/container.yml
@@ -17,7 +17,7 @@
   shell: "{{ item }}"
   with_items:
     - docker build -t sodafoundation/delfin .
-    - DELFIN_METRICS_DIR={{ delfin_exporter_prometheus_metrics_dir }} DELFIN_HOST_IP={{ host_ip }} DELFIN_RABBITMQ_USER={{ delfin_rabbitmq_user }} DELFIN_RABBITMQ_PASS={{ delfin_rabbitmq_pass }} docker compose up -d
+    - DELFIN_REDIS_HOSTNAME=delfin_redis DELFIN_REDIS_PORT={{ delfin_redis_port }} DELFIN_METRICS_DIR={{ delfin_exporter_prometheus_metrics_dir }} DELFIN_HOST_IP={{ host_ip }} DELFIN_RABBITMQ_USER={{ delfin_rabbitmq_user }} DELFIN_RABBITMQ_PASS={{ delfin_rabbitmq_pass }} docker compose up -d
   become: yes
   args:
     chdir: "{{ delfin_work_dir }}"


### PR DESCRIPTION

What this PR does / why we need it:
Update name of delfin redis container because conflict with multicloud redis container

Which issue this PR fixes: 
fixes 

Test Report
![image](https://user-images.githubusercontent.com/118723687/208672946-8f8b57fd-2b70-441f-b804-364db59ab036.png)

