### PR TITLE
Fix setuptools version to 65.0.0

### DIFF
--- a/installer/install_dependencies.sh
+++ b/installer/install_dependencies.sh
@@ -18,9 +18,15 @@ sudo apt-get update
 
 # Install python dependencies
 echo Installing Python dependencies
-sudo apt-get install -y python3-distutils
-sudo apt-get install -y python3-pip
-python3 -m pip install -U pip setuptools
+sudo apt-get install -y python3-distutils python3-testresources python3-pip
+python3 -m pip install -U pip
+
+# Update setuptool version if it is higher than 65
+ver=$(python3 -m pip show setuptools | awk '/^Version: / {sub("^Version: ", ""); print}' | cut -d. -f1)
+if [ "$ver" -gt 65 ]; then
+    echo Downgrade setuptools version to 65
+    python3 -m pip install setuptools==65.0.0
+fi
 
 # Install ansible if not present
 if [ "`which ansible`" != ""  ]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ PasteDeploy>=1.5.0 # MIT
 retrying!=1.3.0,>=1.2.3 # Apache-2.0
 Routes>=2.3.1 # MIT
 six>=1.10.0 # MIT
-SQLAlchemy>=1.3.0 # MIT
+SQLAlchemy==1.4.44 # MIT
 stevedore>=1.20.0 # Apache-2.0
 tooz==2.8.0 # Apache-2.0
 WebOb>=1.7.1 # MIT


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Latest version of SQLAlchemy module is giving error message 

`ERROR: launchpadlib 1.10.13 requires testresources, which is not installed.`

`sqlalchemy failed sqlalchemy.exc.ArgumentError: autocommit=True is no longer supported`

This PR will Keep SQLAlchemy version to older one.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #977 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
