### PR TITLE
Update ansible installer for rabbitmq to remove apt_key usage

### DIFF
--- a/installer/ansible/roles/delfin-installer/scenarios/rabbitmq.yml
+++ b/installer/ansible/roles/delfin-installer/scenarios/rabbitmq.yml
@@ -21,74 +21,13 @@
   apt:
     autoclean: yes
 
-- name: Import RabbitMQ public key
-  apt_key:
-    url: https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
-    state: present
+- name: Install rabbitmq service
+  shell: "{{ item }}"
+  with_items:
+    - bash ./script/install_rabbitmq.sh "{{ ansible_distribution_release }}"
   become: yes
   when:
-    - rabbitmqservice.stat.exists is undefined or rabbitmqservice.stat.exists == false
-
-- name: Add Launchpad Erlang PPA key
-  apt_key:
-    keyserver: keyserver.ubuntu.com 
-    id: F77F1EDA57EBB1CC
-  become: yes
-  when:
-    - rabbitmqservice.stat.exists is undefined or rabbitmqservice.stat.exists == false
-
-- name: Add PackageCloud RabbitMQ repository
-  apt_key:
-    url: https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey
-    state: present
-  become: yes
-  when:
-    - rabbitmqservice.stat.exists is undefined or rabbitmqservice.stat.exists == false
-
-- name: Add RabbitMQ Erlang official repo
-  apt_repository: 
-    repo: deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu {{ ansible_distribution_release }} main
-    state: present
-    filename: rabbitmq
-  become: yes
-  when:
-    - rabbitmqservice.stat.exists is undefined or rabbitmqservice.stat.exists == false
-
-- name: Add RabbitMQ Server official repo
-  apt_repository: 
-    repo: deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ {{ ansible_distribution_release }} main
-    state: present
-    filename: rabbitmq
-  become: yes
-  when:
-    - rabbitmqservice.stat.exists is undefined or rabbitmqservice.stat.exists == false
-
-- name: Import Erlang public key
-  apt_key:
-    url: https://packages.erlang-solutions.com/debian/erlang_solutions.asc
-    state: present
-  become: yes
-  when:
-    - rabbitmqservice.stat.exists is undefined or rabbitmqservice.stat.exists == false
-
-- name: Add Erlang official repo
-  apt_repository:
-    repo: deb https://binaries.erlang-solutions.com/debian {{ ansible_distribution_release }} contrib
-    state: present
-    filename: erlang
-  become: yes
-  when:
-    - rabbitmqservice.stat.exists is undefined or rabbitmqservice.stat.exists == false
-
-- name: Install RabbitMQ package
-  apt: 
-    name: rabbitmq-server
-    update_cache: yes
-    install_recommends: yes
-    allow_unauthenticated: yes
-    state: present
-  become: yes
-  when:
+    - ansible_distribution == 'Ubuntu'
     - rabbitmqservice.stat.exists is undefined or rabbitmqservice.stat.exists == false
 
 - name: Start the RabbitMQ server

--- a/installer/ansible/script/install_rabbitmq.sh
+++ b/installer/ansible/script/install_rabbitmq.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The SODA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#sudo apt-get install curl gnupg apt-transport-https -y
+
+## Team RabbitMQ's main signing key
+curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | sudo gpg --dearmor | sudo tee /usr/share/keyrings/com.rabbitmq.team.gpg > /dev/null
+## Launchpad PPA that provides modern Erlang releases
+curl -1sLf "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf77f1eda57ebb1cc" | sudo gpg --dearmor | sudo tee /usr/share/keyrings/net.launchpad.ppa.rabbitmq.erlang.gpg > /dev/null
+## PackageCloud RabbitMQ repository
+curl -1sLf "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey" | sudo gpg --dearmor | sudo tee /usr/share/keyrings/io.packagecloud.rabbitmq.gpg > /dev/null
+
+release=$1
+
+## Add apt repositories maintained by Team RabbitMQ
+sudo tee /etc/apt/sources.list.d/rabbitmq.list <<EOF
+## Provides modern Erlang/OTP releases
+##
+## "bionic" as distribution name should work for any reasonably recent Ubuntu or Debian release.
+## See the release to distribution mapping table in RabbitMQ doc guides to learn more.
+deb [signed-by=/usr/share/keyrings/net.launchpad.ppa.rabbitmq.erlang.gpg] http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu $release main
+deb-src [signed-by=/usr/share/keyrings/net.launchpad.ppa.rabbitmq.erlang.gpg] http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu $release main
+
+## Provides RabbitMQ
+##
+## "bionic" as distribution name should work for any reasonably recent Ubuntu or Debian release.
+## See the release to distribution mapping table in RabbitMQ doc guides to learn more.
+deb [signed-by=/usr/share/keyrings/io.packagecloud.rabbitmq.gpg] https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ $release main
+deb-src [signed-by=/usr/share/keyrings/io.packagecloud.rabbitmq.gpg] https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ $release main
+EOF
+
+## Update package indices
+sudo apt-get update -y
+
+## Install Erlang packages
+sudo apt-get install -y erlang-base \
+                        erlang-asn1 erlang-crypto erlang-eldap erlang-ftp erlang-inets \
+                        erlang-mnesia erlang-os-mon erlang-parsetools erlang-public-key \
+                        erlang-runtime-tools erlang-snmp erlang-ssl \
+                        erlang-syntax-tools erlang-tftp erlang-tools erlang-xmerl
+
+## Install rabbitmq-server and its dependencies
+sudo apt-get install rabbitmq-server -y --fix-missing


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update ansible installer for rabbitmq to remove apt_key usage. This is required for Ubuntu 22.04

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
