### PR TITLE
unity change ethport's logictype and THROUGHPUT'units as Ki

### DIFF
--- a/delfin/drivers/dell_emc/unity/unity.py
+++ b/delfin/drivers/dell_emc/unity/unity.py
@@ -383,6 +383,9 @@ class UnityStorDriver(driver.StorageDriver):
                                     ipv6, ip_content.get('ipAddress'))
                                 ipv6_mask = UnityStorDriver.handle_port_ip(
                                     ipv6_mask, ip_content.get('netmask'))
+                logical_type = ''
+                if '_mgmt' in content.get('id') or '_srm' in content.get('id'):
+                    logical_type = constants.PortLogicalType.MANAGEMENT
                 port_result = {
                     'name': content.get('name'),
                     'storage_id': self.storage_id,
@@ -391,7 +394,7 @@ class UnityStorDriver(driver.StorageDriver):
                     'connection_status': conn_status,
                     'health_status': status,
                     'type': constants.PortType.ETH,
-                    'logical_type': '',
+                    'logical_type': logical_type,
                     'speed': int(content.get('speed')) * units.M
                     if content.get('speed') is not None else None,
                     'max_speed': int(content.get('speed')) * units.M
@@ -1025,10 +1028,12 @@ class UnityStorDriver(driver.StorageDriver):
                 'type': 'RAW',
                 'unit': unit
             }
-            if 'THROUGHPUT' in metric.get('type').upper() or \
-                    'RESPONSETIME' in metric.get('type').upper():
+            if 'RESPONSETIME' in metric.get('type').upper():
                 for tm in metric.get('values'):
                     metric['values'][tm] = metric['values'][tm] / units.k
+            if 'THROUGHPUT' in metric.get('type').upper():
+                for tm in metric.get('values'):
+                    metric['values'][tm] = metric['values'][tm] / units.Ki
             value = constants.metric_struct(name=metric.get('type'),
                                             labels=labels,
                                             values=metric.get('values'))

--- a/delfin/tests/unit/drivers/dell_emc/unity/test_emc_unity.py
+++ b/delfin/tests/unit/drivers/dell_emc/unity/test_emc_unity.py
@@ -395,7 +395,7 @@ GET_ALL_ETHPORTS = {
     "entries": [
         {
             "content": {
-                "id": "spa_eth0",
+                "id": "spa_srm",
                 "speed": 10000,
                 "connectorType": 1,
                 "requestedSpeed": 0,
@@ -420,7 +420,7 @@ GET_ALL_ETHPORTS = {
                 "maxMtu": 9000,
                 "bond": False,
                 "isLinkUp": True,
-                "macAddress": "00:50:56:81:E1:50",
+                "macAddress": "00:50:56:81:E1:55",
                 "isRSSCapable": False,
                 "isRDMACapable": False,
                 "requestedMtu": 1500,
@@ -616,7 +616,7 @@ GET_ALL_IP = {
                 "ipAddress": "192.168.3.111",
                 "ipProtocolVersion": 4,
                 "ipPort": {
-                    "id": "spa_eth1"
+                    "id": "spa_mgmt"
                 }
             }
         }
@@ -662,17 +662,17 @@ port_result = [
     {
         'name': 'SP A Ethernet Port 0',
         'storage_id': '12345',
-        'native_port_id': 'spa_eth0',
+        'native_port_id': 'spa_srm',
         'location': 'SP A Ethernet Port 0',
         'connection_status': 'connected',
         'health_status': 'normal',
         'type': 'eth',
-        'logical_type': '',
+        'logical_type': 'management',
         'speed': 10000000000,
         'max_speed': 10000000000,
         'native_parent_id': 'spa',
         'wwn': '',
-        'mac_address': '00:50:56:81:E1:50',
+        'mac_address': '00:50:56:81:E1:55',
         'ipv4': None,
         'ipv4_mask': None,
         'ipv6': None,
@@ -691,8 +691,8 @@ port_result = [
         'native_parent_id': 'spa',
         'wwn': '',
         'mac_address': '00:50:56:81:E8:4B',
-        'ipv4': '192.168.3.111',
-        'ipv4_mask': '255.255.255.0',
+        'ipv4': None,
+        'ipv4_mask': None,
         'ipv6': None,
         'ipv6_mask': None
     }, {
@@ -739,14 +739,14 @@ port_result = [
         'connection_status': 'connected',
         'health_status': 'normal',
         'type': 'eth',
-        'logical_type': '',
+        'logical_type': 'management',
         'speed': 10000000000,
         'max_speed': 10000000000,
         'native_parent_id': 'spa',
         'wwn': '',
         'mac_address': '00:50:56:81:E5:05',
-        'ipv4': None,
-        'ipv4_mask': None,
+        'ipv4': '192.168.3.111',
+        'ipv4_mask': '255.255.255.0',
         'ipv6': None,
         'ipv6_mask': None
     }, {

--- a/delfin/tests/unit/drivers/pure/flasharray/test_pure_flasharray.py
+++ b/delfin/tests/unit/drivers/pure/flasharray/test_pure_flasharray.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import sys
-import time
 from unittest import TestCase, mock
 
 import six
 from oslo_log import log
-from oslo_utils import units
 
 from delfin.common import constants
 from delfin.drivers.pure.flasharray import consts
@@ -1777,13 +1775,10 @@ class test_PureFlashArrayDriver(TestCase):
     def test_collect_perf_metrics(self):
         RestHandler.rest_call = mock.Mock(
             side_effect=[storage_id_info, drive_metrics])
-        localtime = time.mktime(time.localtime()) * units.k
         storage_id = 12345
-        start_time = localtime - 1000 * 60 * 60 * 24 * 364
-        end_time = localtime
         metrics = self.driver.collect_perf_metrics(
-            context, storage_id, storage_resource_metrics, start_time,
-            end_time)
+            context, storage_id, storage_resource_metrics, 1619257043000,
+            1653385043000)
         storage_metrics = [
             constants.metric_struct(
                 name='iops',
@@ -1968,8 +1963,8 @@ class test_PureFlashArrayDriver(TestCase):
         RestHandler.rest_call = mock.Mock(
             side_effect=[volume_metrics_info])
         metrics = self.driver.collect_perf_metrics(
-            context, storage_id, volume_resource_metrics, start_time,
-            end_time)
+            context, storage_id, volume_resource_metrics, 1619257043000,
+            1653385043000)
         self.assertListEqual(metrics, volume_metrics)
 
     def test_get_capabilities(self):


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
unity change ethport's logictype and THROUGHPUT'units as Ki

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
