### PR TITLE
EMC vnx block: Obtain IP information for multiple control nodes

### DIFF
--- a/delfin/drivers/dell_emc/vnx/vnx_block/component_handler.py
+++ b/delfin/drivers/dell_emc/vnx/vnx_block/component_handler.py
@@ -901,3 +901,21 @@ class ComponentHandler(object):
                 latest_time = file_latest_time
                 time.sleep(consts.CHECK_WAITE_TIME_SECONDS)
         return latest_time, file_latest_time
+
+    def get_alert_sources(self):
+        try:
+            ip_list = []
+            domains = self.navi_handler.get_domain()
+            if domains:
+                for domain in domains:
+                    host_ip = domain.get('ip_address')
+                    ip_list.append({'host': host_ip})
+            return ip_list
+        except exception.DelfinException as e:
+            err_msg = "Get alerts sources failed: %s" % (e.msg)
+            LOG.error(err_msg)
+            raise e
+        except Exception as e:
+            err_msg = "Get alert sources failed: %s" % (six.text_type(e))
+            LOG.error(err_msg)
+            raise exception.InvalidResults(err_msg)

--- a/delfin/drivers/dell_emc/vnx/vnx_block/vnx_block.py
+++ b/delfin/drivers/dell_emc/vnx/vnx_block/vnx_block.py
@@ -110,3 +110,6 @@ class VnxBlockStorDriver(driver.StorageDriver):
 
     def get_latest_perf_timestamp(self, context):
         return self.com_handler.get_latest_perf_timestamp(self.storage_id)
+
+    def get_alert_sources(self, context):
+        return self.com_handler.get_alert_sources()


### PR DESCRIPTION
What this PR does / why we need it:
1 Obtain IP information for multiple control nodes

Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #

Special notes for your reviewer:

Release note: